### PR TITLE
PSD-27 [fix] Completar cobertura de RNF para transiciones y mensajes de dominio

### DIFF
--- a/docs/diseño/requerimientos/no funcionales/RNF-02 Rendimiento del bot.md
+++ b/docs/diseño/requerimientos/no funcionales/RNF-02 Rendimiento del bot.md
@@ -9,7 +9,13 @@ El bot debe mantener conversaciones fluidas garantizando latencias y throughput 
 - P90 < 2 segundos; P99 < 5 segundos; Máximo < 10 segundos (medidos end-to-end en backend).
 - Carga de referencia: soportar 50 conversaciones concurrentes activas con al menos 10 mensajes de historial cada una.
 - Throughput mínimo objetivo: 600 mensajes por minuto (≈10 msg/s) sin degradar P90/P99 por debajo de los umbrales.
-- En caso de indisponibilidad parcial (p. ej. DB), el sistema debe responder con un mensaje de indisponibilidad en <10 segundos.
+ En caso de indisponibilidad parcial (p. ej. DB), el sistema debe responder con un mensaje de indisponibilidad en <10 segundos.
+ SLA de transición bot↔operador (CU-COM-001):
+  - Time-to-assign (TTA): tiempo desde que el Sistema recibe la señal de escalamiento/transferencia hasta que el operador recibe la conversación en su bandeja y el contexto mínimo requerido: P90 ≤ 3 s; P99 ≤ 10 s; Máx ≤ 20 s.
+  - Time-to-resume-bot (TTRB): tiempo desde que el operador libera la conversación hasta que el bot puede reanudar la interacción: P90 ≤ 3 s; P99 ≤ 10 s; Máx ≤ 20 s.
+  - Latencia de notificación al usuario sobre la transferencia: ≤ 3 s (mensaje indicativo de que la conversación está siendo transferida).
+  - Completitud del contexto: el histórico mínimo configurable (p. ej. últimos 20 mensajes y metadatos relevantes) debe estar disponible para el operador al 100 % en la transferencia.
+  - Ventana de aceptación del operador: tiempo máximo para que un operador acepte la asignación antes de aplicar políticas de reencolamiento o escalado: 60 s.
 
 ## Condiciones
 
@@ -19,6 +25,12 @@ El bot debe mantener conversaciones fluidas garantizando latencias y throughput 
 - Instrumentación: traces y timestamps que permitan calcular P90, P99 y throughput por ventana (p. ej. 1 hora).
 - Degradación graceful: al alcanzar condiciones de saturación (umbral configurable; p. ej. 500 conversaciones simultáneas) el sistema debe rechazar nuevas solicitudes con un mensaje de espera/cola o un 429/503 bien documentado, en vez de caer.
 - Las pruebas de carga deben ser reproducibles y ejecutar escenarios con 50 conversaciones concurrentes y datos representativos.
+- Para las transiciones bot↔operador:
+  - Las mediciones de TTA/TTRB deben ser end-to-end e incluir latencias de conectores y UI de operador; los tiempos se registran por trace-id asociado a la conversación.
+  - Durante la transferencia el bot debe dejar de generar respuestas automáticas en menos de 1s tras iniciar la transferencia para evitar errores cuando el bot y el operador actuen sobre la misma conversación simultaneamente.
+  - El orquestador debe propagar el contexto y datos al operador en una única operación atómica visible en los logs.
+  - Si la aceptación del operador excede la ventana de 60s, se debe aplicar la política configurada (reintento, re-asignación, fallback a cola o mensaje al usuario) y documentar el evento en telemetría.
+  - Las pruebas de integración deben incluir escenarios de asignación concurrente (p. ej. 10–50 asignaciones simultáneas) para validar TTA/TTRB bajo carga.
 
 ## Criterios de aceptación
 

--- a/docs/diseño/requerimientos/no funcionales/RNF-03 Claridad de mensajes del bot.md
+++ b/docs/diseño/requerimientos/no funcionales/RNF-03 Claridad de mensajes del bot.md
@@ -35,7 +35,7 @@ Los mensajes del bot deben ser precisos, verificables y comprensibles para el Cl
   - Nunca exponer excepciones, stack traces, IDs internos, tokens o nombres de tablas.
   - Incluir metadatos estructurados en la respuesta (no visibles al usuario) con campos: `error_code`, `retryable` (boolean), `severity` (info/warn/error), `trace_id`.
   - Tiempo máximo para presentar el mensaje de fallo al usuario: ≤ 2 s desde la detección del error.
-  - Si la operación es reintento-able, el sistema debe permitir reintentos automáticos con backoff configurado y notificar al usuario del intento.
+  - Si la operación es reintentable, el sistema debe permitir reintentos automáticos con backoff configurado y notificar al usuario del intento.
 
 - Condiciones de validación:
   - Se construirán pruebas automáticas para los escenarios más frecuentes (reservas, transiciones de etapa, bloqueo por regla de negocio) que verifiquen:

--- a/docs/diseño/requerimientos/no funcionales/RNF-03 Claridad de mensajes del bot.md
+++ b/docs/diseño/requerimientos/no funcionales/RNF-03 Claridad de mensajes del bot.md
@@ -21,9 +21,33 @@ Los mensajes del bot deben ser precisos, verificables y comprensibles para el Cl
 - Validación: revisión de 10 flujos de prueba documentados para verificar ausencia de confirmaciones explícitas en contextos informativos.
 - Para el conteo de palabras, "mensajes comunes" excluyen listados de eventos, descripciones completas y textos legales (aviso de privacidad).
 
+## Patrón de mensaje ante fallos de operación de dominio
+
+- Descripción: cuando una operación de dominio falla, el bot debe responder con un patrón estandarizado que sea informativo, seguro y accionable para el usuario.
+- Estructura del mensaje (plantilla mínima):
+  - Encabezado breve y amable (p. ej. "No fue posible completar la acción").
+  - Frase con motivo en lenguaje de usuario (sin tecnicismos ni trazas internas): p. ej. "No hay cupos disponibles para la fecha solicitada".
+  - Código de error amigable opcional (p. ej. "ERR-RES-01") para correlación en soporte y logs (solo visible en texto si aplica).
+  - Acciones recomendadas: lista de hasta 3 opciones; reintentar, suscribirse a lista de espera (en caso de ser prospecto) o contactar a un operador.
+  - Si es recuperable, ofrecer opción de reintento automático y estimación de tiempo si procede.
+
+- Reglas y métricas:
+  - Nunca exponer excepciones, stack traces, IDs internos, tokens o nombres de tablas.
+  - Incluir metadatos estructurados en la respuesta (no visibles al usuario) con campos: `error_code`, `retryable` (boolean), `severity` (info/warn/error), `trace_id`.
+  - Tiempo máximo para presentar el mensaje de fallo al usuario: ≤ 2 s desde la detección del error.
+  - Si la operación es reintento-able, el sistema debe permitir reintentos automáticos con backoff configurado y notificar al usuario del intento.
+
+- Condiciones de validación:
+  - Se construirán pruebas automáticas para los escenarios más frecuentes (reservas, transiciones de etapa, bloqueo por regla de negocio) que verifiquen:
+  - El mensaje cumple la plantilla (encabezado + motivo + acciones recomendadas).
+  - No hay exposición de identificadores internos ni errores técnicos.
+  - La telemetría registra el `error_code` y `trace_id` para correlación con logs.
+
 ## Criterios de aceptación
 
 - En consultas sobre un Evento, los valores entregados por el bot coinciden exactamente con los almacenados en banco de contexto de evento.
 - En revisión de 10 flujos de prueba documentados, ningún mensaje contiene patrones de identificadores internos ni la estructura '¿Quieres [verbo] [objeto]?' en contextos informativos.
 - En mensajes comunes, la longitud no supera 100 palabras y no hay errores ortográficos.
 - Si se aplica, la medición de legibilidad alcanza el nivel B1 en el conjunto de pruebas.
+- Cuando una operación de dominio retorna error (reservas, transiciones de etapa, consultas al banco de contexto), el bot utiliza una plantilla de indisponibilidad predefinida tomada del `banco de contexto general` y no inventa valores.
+- Existe una lista versionada de plantillas de error en el `banco de contexto general`; las pruebas automatizadas verifican que en cada escenario de fallo se use la plantilla correspondiente en vez de generar contenido nuevo.

--- a/docs/diseño/requerimientos/no funcionales/RNF-05 Disponibilidad del sistema.md
+++ b/docs/diseño/requerimientos/no funcionales/RNF-05 Disponibilidad del sistema.md
@@ -12,9 +12,37 @@ El sistema (bot + backend) debe estar disponible para procesar conversaciones en
 ## Condiciones
 
 - Se mide con un monitor externo que realiza health-checks al endpoint de salud del backend cada 60 segundos.
-- Se excluyen fallos en plataformas de mensajería fuera del control del sistema (WhatsApp y en el futuro otras redes sociales).
-- El endpoint de salud deberá considerar como disponibles los subsistemas críticos (base de datos, colas, servicio de mensajería) antes de devolver estado OK.
+- Se mide con un monitor externo que realiza health-checks al endpoint de salud del backend cada 60 segundos.
+- El endpoint de salud mide únicamente los subsistemas propios necesarios para el procesamiento de conversaciones (p. ej. base de datos, colas, backend/orquestador). Los canales externos (WhatsApp y en el futuro otras redes sociales) se monitorizan por separado como dependencias; su indisponibilidad no computa contra el SLA del sistema, pero sí genera alerta operativa.
 - Las ventanas de mantenimiento deben registrarse y notificarse con al menos 24 horas de anticipación.
+- El endpoint de salud debe devolver un JSON estructurado que distinga entre `internal_status` y `external_dependencies`. Solo `internal_status` se utilizará para el cálculo del SLA (uptime del servicio), mientras que `external_dependencies` reporta disponibilidad de proveedores externos sin contar como downtime en el SLA.
+- Ejemplo mínimo de respuesta de salud (simplificada):
+
+```json
+{
+"status": "OK",
+    "internal_status": "OK",
+    "external_dependencies": {
+        "whatsapp_connector": "DEGRADED",
+        "sms_gateway": "OK"
+    },
+    "timestamp": "..."
+}
+```
+
+- Las comprobaciones internas (base de datos, colas, bus de mensajes, orquestador) son críticas y su fallo computa como downtime para la métrica de disponibilidad.
+- Las comprobaciones de conectores a proveedores externos (WhatsApp, SMS, Facebook, etc.) se monitorizan y generan alertas, pero su indisponibilidad no se contabiliza como downtime del sistema salvo que exista un acuerdo explicito que los incluya en el SLA.
+- Métricas y objetivos adicionales sobre dependencias externas:
+  - Tiempo de detección de fallo externo (monitor): ≤ 2 minutos tras la primera comprobación fallida.
+  - Tiempo máximo para generar alerta y notificación al equipo de operaciones: ≤ 5 minutos.
+  - RTO objetivo para reconexión a proveedor externo: ≤ 60 minutos (cuando aplique).
+  - Política de degradación: al detectarse un fallo externo, el sistema debe:
+    - Marcar la dependencia como `DEGRADED` en el endpoint de salud y dashboard.
+    - Poner en cola las operaciones salientes dirigidas a ese proveedor y reportar el número de mensajes en cola.
+    - Informar al usuario con un mensaje amigable cuando la acción dependa del canal (p. ej. "Actualmente no podemos enviar mensajes por WhatsApp; podemos notificarle por SMS o avisarle cuando se restablezca").
+- Reglas de cálculo del SLA:
+  - El monitor externo debe calcular el SLA utilizando únicamente la serie temporal de `internal_status` del endpoint de salud.
+  - Eventos de downtime ocasionados exclusivamente por proveedores externos quedan reflejados en reportes de "dependencias de terceros" y no afectan el porcentaje de disponibilidad definido en este RNF.
 
 ## Criterios de aceptación
 


### PR DESCRIPTION
<!--
Pull Request Template
- Manténlo concreto.
- Incluye trazabilidad obligatoria a Issue.
-->

Closes #77 <!-- issue-number -->

## Tipo de cambio
- [ ] Docs (documentación)
- [ ] Feature (funcionalidad/código)
- [x] Fix (corrección)
- [ ] Chore (mantenimiento)

## Contexto
Completar los tres RNF con las métricas o condiciones faltantes para que cubran el comportamiento real del sistema orquestador

## Cambios
- [x] RNF-02 — Añadido SLA para transiciones bot↔operador (TTA/TTRB, P90 ≤ 3 s).
- [x] RNF-03 — Añadida plantilla de indisponibilidad en el banco de contexto general y criterio de aceptación verificable.
- [x] RNF-05 — Clarificado health-check: mide solo subsistemas propios; canales externos monitorizados por separado.

## Entregables / Rutas
Incluye rutas exactas de archivos relevantes.

- `SoftwareDesignProject\docs\diseño\requerimientos\no funcionales\RNF-02 Rendimiento del bot.md`
- `SoftwareDesignProject\docs\diseño\requerimientos\no funcionales\RNF-03 Claridad de mensajes del bot.md`
- `SoftwareDesignProject\docs\diseño\requerimientos\no funcionales\RNF-05 Disponibilidad del sistema.md`

### Checklist específico — Weeklies (si aplica)
- [ ] Transcripción creada/actualizada en `docs/meetings/transcripciones/` con `trs-dd-mm-<tema>.md`
- [ ] Resumen creado/actualizado en `docs/meetings/resumenes/` con `rsm-dd-mm-<tema>.md`

## Evidencia
- Capturas / logs / enlaces (si aplica).

## Notas y riesgos
- Tengo dudas del RNF-03, específicamente en la linea 31 si debería incluir "suscribirse a lista de espera (en caso de ser prospecto)"
