### PR TITLE
correciones a los casos de uso y los rf

### DIFF
--- a/docs/diseño/casos de uso/COM/CU-COM-003 Gestion de bancos de contexto.md
+++ b/docs/diseño/casos de uso/COM/CU-COM-003 Gestion de bancos de contexto.md
@@ -120,6 +120,7 @@ El Bot requiere información del sistema para responder a una consulta de la Per
    - `reserva_temporal`: decrementa los cupos disponibles en 1 y registra la reserva temporal asociada a la Persona interesada con un timestamp de expiración. [RF-EVT-02]
    - `liberacion_reserva`: incrementa los cupos disponibles en 1 y elimina el registro de reserva temporal de la Persona interesada. [RF-EVT-02]
    - `bloqueo_cupo`: convierte la reserva temporal en definitiva tras confirmación de pago y marca el cupo como ocupado de forma permanente. [RF-EVT-04]
+   - `registro_desuscripcion`: registra la preferencia de desuscripción de la Persona interesada en el Banco de contexto general para evitar futuras notificaciones de reactivación. [CU-COM-006]
 5. El Sistema registra la operación con timestamp en los logs del sistema. [RF-EVT-02] [RF-EVT-04]
 6. El Sistema confirma al Bot que la operación se realizó correctamente.
 7. El Bot adapta el flujo conversacional en función del resultado de la operación.
@@ -175,7 +176,7 @@ El Bot requiere información del sistema para responder a una consulta de la Per
 - RN-COM-03-03: La información del Banco de contexto de evento debe estar marcada como activa para ser entregada al Bot.
 - RN-COM-03-04: Los bancos de contexto pueden entregarse completos o por partes según la granularidad de la solicitud.
 - RN-COM-03-05: El banco de contexto general solo entregará eventos que coincidan con el estado de evento solicitado por el Bot (por ejemplo, solo eventos activos, historial de eventos pasados para eventos anuales, eventos en curso, etc.)
-- RN-COM-03-06: Las operaciones de escritura sobre el Banco de contexto de evento solo pueden ser solicitadas por el Bot como consecuencia directa del proceso de venta gestionado por CU-COM-002; ninguna operación de escritura de cupo puede ejecutarse fuera de ese contexto salvo intervención manual de un operador humano.
+- RN-COM-03-06: Las operaciones de escritura sobre el Banco de contexto de evento solo pueden ser solicitadas por el Bot como consecuencia directa del proceso de venta gestionado por CU-COM-002 o del proceso de inscripción gestionado por CU-EVT-003; ninguna operación de escritura de cupo puede ejecutarse fuera de ese contexto salvo intervención manual de un operador humano.
 
 ## Datos relevantes
 
@@ -187,7 +188,7 @@ El Bot requiere información del sistema para responder a una consulta de la Per
 
 ### Entradas — Actualización de banco de contexto de evento
 
-- Tipo de operación: `reserva_temporal`, `liberacion_reserva`, `bloqueo_cupo`
+- Tipo de operación: `reserva_temporal`, `liberacion_reserva`, `bloqueo_cupo`, `registro_desuscripcion`
 - Identificador del Evento
 - Identificador de la Persona interesada
 

--- a/docs/diseño/casos de uso/COM/CU-COM-006 Gestión de notificaciones de reactivación.md
+++ b/docs/diseño/casos de uso/COM/CU-COM-006 Gestión de notificaciones de reactivación.md
@@ -24,7 +24,7 @@ Aplica a toda comunicación outbound iniciada por el sistema bot hacia clientes 
 
 ## RF relacionados
 
-- (pendiente de definición de RF específico para notificaciones outbound de reactivación)
+- [RF-COM-08 Gestión de notificaciones de reactivación outbound]
 
 ## Actores
 

--- a/docs/diseño/casos de uso/EVT/CU-EVT-002 Gestión de cancelación.md
+++ b/docs/diseño/casos de uso/EVT/CU-EVT-002 Gestión de cancelación.md
@@ -69,12 +69,16 @@ El Usuario decide cancelar una inscripción de un Evento antes de su inicio.
 1. El Usuario selecciona una inscripción confirmada
 2. El Sistema valida que el Evento no ha iniciado
 3. El Sistema permite ejecutar la cancelación
-4. El Sistema cambia el estado de la inscripción a cancelada conforme a las causas excepcionales de liberación definidas en [RF-EVT-04]
+4. El Sistema cambia el estado de la inscripción a cancelada por decisión operativa del Usuario (cancelación pre-inicio, anterior a cualquier causa excepcional)
 5. El Sistema libera la vacante asociada
 6. El Sistema actualiza el cupo disponible
 7. El Sistema registra la cancelación (usuario, fecha, motivo)
 8. El Sistema verifica si existe lista de espera
 9. Si existe, el Sistema dispara notificación al siguiente elegible [RF-EVT-03]
+
+## Nota aclaratoria
+
+RF-EVT-04 cubre liberaciones post-confirmación de pago por causas excepcionales (Ausencia confirmada, Extemporáneo, Solicitud de reembolso). Este caso de uso (CU-EVT-002) cubre cancelaciones pre-inicio, anteriores a la confirmación de pago, ejecutadas por decisión operativa del Usuario antes de que el Evento inicie.
 
 ## Flujos alternos
 

--- a/docs/diseño/requerimientos/funcionales/COM/RF-COM-02 Gestión de etapa comercial y calificación automática de leads.md
+++ b/docs/diseño/requerimientos/funcionales/COM/RF-COM-02 Gestión de etapa comercial y calificación automática de leads.md
@@ -49,5 +49,5 @@ El sistema debe gestionar las siguientes etapas comerciales asociadas a cada per
 - [ ] El sistema asigna automáticamente una calificación a la persona interesada  
 - [ ] La persona interesada recibe un nivel de prioridad: alto, medio o bajo  
 - [ ] El nivel de calificación queda registrado en la base de datos  
-- [ ] La calificación puede influir en la priorización de atención y en la actualización de la etapa comercial  
+- [ ] La calificación influye exclusivamente en la priorización operativa; no produce ni dispara cambios de etapa  
 - [ ] El sistema notifica al equipo humano cuando se identifica una persona interesada con prioridad alta

--- a/docs/diseño/requerimientos/funcionales/COM/RF-COM-08 Gestión de notificaciones de reactivación outbound.md
+++ b/docs/diseño/requerimientos/funcionales/COM/RF-COM-08 Gestión de notificaciones de reactivación outbound.md
@@ -1,0 +1,52 @@
+# RF-COM-08 Gestión de notificaciones de reactivación outbound
+
+## Descripción
+
+El sistema debe ser capaz de enviar notificaciones outbound de forma proactiva a los clientes potenciales registrados en la cartera de clientes (Prospectos, SQLs y Alumnos activos) cuando ocurran eventos comerciales relevantes, con el objetivo de reactivar su proceso comercial y mantenerlos informados sobre nuevas oportunidades.
+
+Las notificaciones outbound solo se envían a destinatarios que han registrado consentimiento tácito de acuerdo a lo establecido en CU-COM-004, garantizando cumplimiento con normativas de protección de datos. El sistema debe permitir a los clientes potenciales solicitar la desuscripción de notificaciones de reactivación, y registrar dicha preferencia en el Banco de contexto general.
+
+## Historia de Usuario
+
+**Como** gerente comercial  
+**Quiero** que el sistema envíe notificaciones proactivas a mis clientes potenciales cuando se reabra un evento o se publique uno relacionado  
+**Para** mantener a mis clientes informados de nuevas oportunidades y reactivar su interés en la inscripción, incrementando las tasas de conversión
+
+## Disparadores de notificación
+
+El sistema debe soportar los siguientes disparadores para activar el envío de notificaciones:
+
+- **Evento reabierto:** Se registra una nueva edición o reapertura de un evento que ya existía en el sistema.
+- **Evento relacionado:** Se publica un nuevo evento cuya categoría, temática o instructor coincide con eventos previos de interés del cliente potencial.
+- **Desuscripción solicitada:** Un cliente potencial solicita explícitamente no recibir más notificaciones de reactivación.
+
+## Criterios de Aceptación
+
+### Gestión de destinatarios
+
+- [ ] El sistema identifica automáticamente los clientes potenciales en etapa Prospecto, SQL o Cierre Ganado (Alumno activo) elegibles para recibir notificaciones.
+- [ ] El sistema valida que cada destinatario tiene consentimiento tácito registrado antes de enviar cualquier notificación.
+- [ ] El sistema omite a los destinatarios que han solicitado desuscripción.
+- [ ] El sistema previene envío repetido aplicando un período anti-spam configurable.
+
+### Envío de notificaciones
+
+- [ ] Las notificaciones se envían a través del canal de comunicación registrado del cliente potencial.
+- [ ] El sistema registra cada envío con timestamp, destinatario y resultado en los logs.
+- [ ] El sistema continúa con el siguiente destinatario incluso si falla el envío a uno específico.
+- [ ] Los destinatarios que responden a la notificación pueden iniciar un nuevo flujo conversacional.
+
+### Gestión de desuscripción
+
+- [ ] Un cliente potencial puede solicitar desuscripción de notificaciones de reactivación a través de una respuesta en el canal.
+- [ ] El sistema registra la preferencia de desuscripción en el Banco de contexto general.
+- [ ] El sistema envía confirmación al cliente potencial indicando que su solicitud fue procesada.
+- [ ] Un cliente potencial desuscrito no recibirá futuras notificaciones mientras la preferencia esté activa.
+- [ ] La preferencia de desuscripción puede ser revertida únicamente por el Operador administrativo del canal o por el cliente potencial mediante una nueva solicitud explícita.
+
+### Restricciones y reglas de negocio
+
+- [ ] El envío de notificaciones no modifica etapas comerciales ni calificaciones.
+- [ ] El envío de notificaciones no inicia automáticamente un flujo comercial; solo coloca el mensaje en el canal del destinatario.
+- [ ] La única operación de escritura permitida es el registro o eliminación de la preferencia de desuscripción en el Banco de contexto general.
+- [ ] Los criterios para determinar si un evento es "relacionado" son configurables por el Operador administrativo del canal.

--- a/docs/diseño/requerimientos/funcionales/EVT/RF-EVT-02 Reservacion de vacante durante proceso de venta.md
+++ b/docs/diseño/requerimientos/funcionales/EVT/RF-EVT-02 Reservacion de vacante durante proceso de venta.md
@@ -2,18 +2,18 @@
 
 ## Descripción
 
-Cuando un Cliente potencial en etapa **MQL** en transición a **Prospecto** manifiesta intención de inscripción y hay cupo disponible, el Sistema debe reservar temporalmente una vacante del Evento para esa Cliente potencial. El tiempo de la vacante reservada debe poder ser configurado por el administrador del sistema, y puede variar por Evento, este tiempo de tolerancia se almacena en el banco de contexto. Si el Cliente potencial no puede confirmar su inscripción por un operador humano en la etapa **SQL** dentro del tiempo de reserva, la vacante se libera automáticamente para que otros interesados puedan tomarla, y el sistema registra el evento en el historial del Cliente potencial y del Evento.
+Cuando el Cliente potencial transiciona a **Prospecto** y hay cupo disponible, el Sistema debe reservar temporalmente una vacante del Evento para ese Cliente potencial. El tiempo de la vacante reservada debe poder ser configurado por el administrador del sistema, y puede variar por Evento, este tiempo de tolerancia se almacena en el banco de contexto. Si el Cliente potencial no puede confirmar su inscripción por un operador humano en la etapa **SQL** dentro del tiempo de reserva, la vacante se libera automáticamente para que otros interesados puedan tomarla, y el sistema registra el evento en el historial del Cliente potencial y del Evento.
 
 ## Historia de usuario
 
-**Como** Cliente potencial que ha mostrado interés en inscribirse a un Evento y se encuentra en etapa MQL,
+**Como** Cliente potencial que transiciona a Prospecto e intenta inscribirse a un Evento,
 **Quiero** que el sistema reserve temporalmente una vacante del Evento para mí durante el proceso de inscripción con una ventana de tiempo explícita,
 **Para** asegurar que puedo completar mi inscripción sin perder la oportunidad debido a la disponibilidad de cupo, y para tener claridad sobre el tiempo que tengo para confirmar mi inscripción.
 
 ## Criterios de aceptación
 
 * [ ] La reserva se activa cuando:
-  * El Cliente potencial en etapa **MQL** manifiesta intención de inscripción, **y**
+  * El Cliente potencial transiciona a **Prospecto**
   * Existe al menos una vacante disponible en el Evento.
 * [ ] La reserva tiene una duración **configurable por el administrador del sistema** y puede variar **por Evento**; este tiempo de tolerancia se almacena en el **banco de contexto**.
 * [ ] Mientras la reserva está activa:
@@ -21,4 +21,4 @@ Cuando un Cliente potencial en etapa **MQL** en transición a **Prospecto** mani
   * Otros interesados **no pueden tomar** esa vacante.
 * [ ] Si el Cliente potencial no confirma su inscripción a través de un operador humano en la etapa **SQL** dentro del tiempo de reserva:
   * La vacante se **libera automáticamente** para que otros interesados puedan tomarla.
-  * El Sistema registra el evento en el historial del **Cliente potencial** y del **Evento** (timestamp y causa).
+  * El Sistema registra el evento en el historial del **Cliente potencial** y del **Evento** .


### PR DESCRIPTION
Closes #76 

## Tipo de cambio
- [x] Docs (documentación)
- [ ] Feature (funcionalidad/código)
- [x] Fix (corrección)
- [ ] Chore (mantenimiento)

## Contexto
Se identificaron inconsistencias semánticas y referencias rotas entre requerimientos funcionales, casos de uso y glosario del módulo comercial y de eventos.

Las principales problemáticas corregidas incluyen:
- Contradicción entre RF-COM-02 y CU-COM-005 respecto a si la calificación puede modificar etapas comerciales.
- Desalineación del disparador de reserva definido en RF-EVT-02 respecto al glosario y CU-COM-002.
- Referencia incorrecta a RF-EVT-04 dentro de cancelaciones pre-inicio en CU-EVT-002.
- Restricción incompleta de orígenes válidos de escritura de cupo en CU-COM-003.
- Ausencia de RF asociado a CU-COM-006, rompiendo trazabilidad RF↔CU.

El objetivo del PR es restaurar consistencia documental, semántica y de trazabilidad entre artefactos.

## Cambios
- [x] Corrección de semántica en RF-COM-02 para eliminar relación entre calificación y cambio de etapa.
- [x] Ajuste del disparador de reserva en RF-EVT-02 alineado con transición a Prospecto.
- [x] Corrección de referencia normativa en CU-EVT-002 para cancelaciones pre-inicio.
- [x] Inclusión de CU-EVT-003 como origen válido de escritura de cupo en CU-COM-003.
- [x] Incorporación del tipo de operación `registro_desuscripcion`.
- [x] Creación de RF-COM-08 para respaldar CU-COM-006.
- [x] Restauración de trazabilidad RF↔CU en CU-COM-006.

## Entregables / Rutas

- `docs/diseño/requerimientos/funcionales/COM/RF-COM-02*.md`
- `docs/diseño/requerimientos/funcionales/EVT/RF-EVT-02*.md`
- `docs/diseño/casos de uso/EVT/CU-EVT-002 Gestión de cancelación.md`
- `docs/diseño/casos de uso/COM/CU-COM-003 Gestion de bancos de contexto.md`
- `docs/diseño/requerimientos/funcionales/COM/RF-COM-08 Gestión de notificaciones de reactivación outbound.md`
- `docs/diseño/casos de uso/COM/CU-COM-006 Gestión de notificaciones de reactivación.md`

### Checklist específico — Weeklies (si aplica)
- [ ] Transcripción creada/actualizada en `docs/meetings/transcripciones/` con `trs-dd-mm-<tema>.md`
- [ ] Resumen creado/actualizado en `docs/meetings/resumenes/` con `rsm-dd-mm-<tema>.md`

## Evidencia
- Validación cruzada entre RF, CU y glosario.
- Verificación de trazabilidad RF↔CU posterior a correcciones.
- Revisión de consistencia de reglas de negocio y eventos de escritura de cupo.

## Notas y riesgos
- Este PR modifica semántica documental y trazabilidad, pero no introduce cambios funcionales de implementación.
- Se recomienda revisión posterior del catálogo completo de RF/CU para detectar referencias indirectas similares.
- RF-COM-08 fue creado para evitar futuros vacíos de trazabilidad documental.