### PR TITLE
PSD-23 [Docs] Ajustar campos específicos de casos de uso para alinearse a los nuevos procesos

### DIFF
--- a/docs/diseño/casos de uso/COM/CU-COM-001 Asignación de conversaciones de un bot a un operador humano.md
+++ b/docs/diseño/casos de uso/COM/CU-COM-001 Asignación de conversaciones de un bot a un operador humano.md
@@ -6,9 +6,9 @@
 - Dominio: COM
 - Nombre: Asignación de conversaciones de un canal de comunicación a Bot
 - Estado: Borrador
-- Versión: v0.4
+- Versión: v0.5
 - Fecha de creación: 2026-03-08
-- Última actualización: 2026-04-28
+- Última actualización: 2026-05-05
 - Responsable: Maximiliano Carrillo Alvarado
 - Última corrección por: Isaac Ortiz
 - Issue relacionado: PSD-08, PSD-13
@@ -16,11 +16,17 @@
 
 ## Objetivo
 
-Permitir que el sistema automáticamente vincule al canal de comunicación entrante un Bot automatizado, con el fin de garantizar una atención rápida, organizada y escalable a los usuarios.
+Orquestar la asignación automática de conversaciones entre canales de comunicación, el Bot automatizado y operadores humanos, garantizando una atención rápida, organizada y escalable. El sistema gestiona todas las transiciones: asignación inicial del canal al Bot, escalamiento del Bot al operador humano cuando sea necesario, y devolución del operador humano al Bot cuando aplique.
 
 ## Alcance
 
-Cubre el escenario en que una persona interesada inicia una conversación en un canal de comunicación hasta la asignación de dicha conversación a un operador humano cuando el bot no pueda continuar. Incluye cola de espera, selección de operador humano disponible y registro de logs.
+Cubre el ciclo completo de control conversacional del sistema:
+
+1. Asignación inicial del canal entrante al Bot automatizado.
+2. Escalamiento del Bot al operador humano cuando el Bot no pueda continuar (Lead, MQL, Prospecto sin resolución o SQL por confirmación de pago).
+3. Devolución del operador humano al Bot cuando la conversación regresa a una etapa automatizable.
+4. Gestión de colas de espera cuando no hay operadores disponibles.
+5. Registro de auditoría completo de todas las transiciones.
 
 ## RF relacionados
 

--- a/docs/diseño/casos de uso/COM/CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot.md
+++ b/docs/diseño/casos de uso/COM/CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot.md
@@ -1,14 +1,14 @@
-# CU-COM-002 Flujo de la conversación entre la Persona interesada y el Bot
+# CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot
 
 ## Metadatos
 
 - ID: CU-COM-002
 - Dominio: COM
-- Nombre: Flujo de la conversación entre la Persona interesada y el Bot
+- Nombre: Flujo de la conversación entre el Cliente potencial y el Bot
 - Estado: Borrador
-- Versión: v0.3
+- Versión: v0.4
 - Fecha de creación: 2026-03-08
-- Última actualización: 2026-04-28
+- Última actualización: 2026-05-05
 - Responsable: Maximiliano Carrillo Alvarado
 - Última corrección por: Isaac Ortiz
 - Issue relacionado: PSD-15
@@ -16,11 +16,11 @@
 
 ## Objetivo
 
-Describir el flujo de interacción entre el Cliente potencial y el Bot, desde el inicio de la conversación hasta el punto de escalamiento a un operador humano o abandono.
+Describir el flujo de interacción entre el Cliente potencial y el Bot, desde la asignación automática del bot por el sistema hasta el punto de escalamiento a un operador humano, cambio de evento, o abandono. Cubre la captura de datos, consulta de eventos, validación de disponibilidad, reserva de cupo e inscripción temporal.
 
 ## Alcance
 
-Aplica al módulo de conversación del sistema bot, incluyendo consulta de eventos, validación de disponibilidad, entrega de información y transición a atención por operador humano.
+Aplica al módulo de conversación del sistema bot, incluyendo consulta de eventos, validación de disponibilidad, entrega de información y transición a atención por operador humano o gestión de lista de espera.
 
 ## RF relacionados
 
@@ -35,7 +35,7 @@ Aplica al módulo de conversación del sistema bot, incluyendo consulta de event
 
 ### Actor principal
 
-- Cliente potencial: inicia la conversación para obtener información sobre eventos y potencialmente inscribirse.
+- Cliente potencial: interactúa con el Bot ya asignado por el sistema para obtener información sobre eventos y potencialmente inscribirse.
 
 ### Actores secundarios
 
@@ -44,7 +44,7 @@ Aplica al módulo de conversación del sistema bot, incluyendo consulta de event
 
 ## Disparador
 
-El Cliente potencial inicia una conversación con el Bot y realiza una consulta sobre un evento.
+El sistema ha asignado un Bot a la conversación del Cliente potencial en el canal de comunicación, y el Cliente potencial inicia la interacción.
 
 ## Precondiciones
 
@@ -79,7 +79,7 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 9. El Cliente potencial muestra interés en inscribirse con preguntas clave como métodos de pago y procesos de inscripción.
 10. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener la disponibilidad de cupo del Evento. [RF-EVT-01]
 11. Haya o no haya cupo, se activa el [CU-COM-005 Gestión de etapa comercial].
-12. Si hay cupo reserva uno temporal para el Cliente potencial y activa [CU-COM-003 Gestión de bancos de contexto]. [RF-EVT-02]
+12. Si hay cupo se activa [CU-EVT-003 Gestión de cupos de eventos] para reservar un cupo temporal para el Cliente potencial. [RF-EVT-02]
 13. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener información de métodos de pago y proceso de inscripción, y el Bot la presenta al Cliente potencial. [RF-COM-04]
 14. El Bot detecta que el cliente potencial ha enviado mensajes que detonan la necesidad de confirmación de pago por parte de un operador humano por lo tanto se activa el [CU-COM-005 Gestión de etapa comercial].
 15. El Bot informa que será transferido a un operador humano y se activa el flujo de [CU-COM-001 Asignación de conversaciones de un bot a un operador humano].
@@ -91,7 +91,7 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 1. Desde el paso 5 hasta el paso 13, el Cliente potencial solicita otras opciones de eventos disponibles.
 2. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener el listado de eventos disponibles y el Bot lo presenta. [RF-COM-04]
 3. El Cliente potencial selecciona un evento diferente al original.
-4. Si el Cliente potencial está en la etapa comercial Prospecto, el Bot quita el cupo reservado para el evento original, activa [CU-COM-003 Gestión de bancos de contexto] y regresa al paso 5.
+4. Si el Cliente potencial está en la etapa comercial Prospecto, el Bot solicita a [CU-EVT-003 Gestión de cupos de eventos] que libere el cupo reservado del evento original y regresa al paso 5.
 
 ### A2. El Cliente potencial desea inscribirse directamente
 
@@ -128,7 +128,7 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 
 ### E3. No aceptación de privacidad
 
-1. En el paso 2, la Persona interesada no continua la conversación después de recibir el aviso de privacidad y términos y condiciones. [RF-COM-07]
+1. En el paso 2, el Cliente potencial no continua la conversación después de recibir el aviso de privacidad y términos y condiciones. [RF-COM-07]
 2. El Bot detecta falta de respuesta y deja la conversación en "hold".
 3. El flujo se detiene.
 
@@ -143,7 +143,7 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 
 ### Entradas
 
-- Consulta de la Persona interesada
+- Consulta del Cliente potencial
 - Evento seleccionado
 
 ### Salidas
@@ -158,7 +158,7 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 ## Observaciones
 
 - El flujo puede variar dependiendo del nivel de interés.
-- La calificación de la Persona interesada ocurre en paralelo (RF-COM-02).
+- La calificación del Cliente potencial ocurre en paralelo (RF-COM-02).
 
 ## Trazabilidad
 
@@ -179,3 +179,4 @@ El Cliente potencial inicia una conversación con el Bot y realiza una consulta 
 [CU-COM-004 Presentación de avisos legales y registro de consentimiento tácito]: /docs/diseño/casos%20de%20uso/COM/CU-COM-004%20Presentación%20de%20avisos%20legales%20y%20registro%20de%20consentimiento%20tácito.md
 [CU-COM-005 Gestión de etapa comercial]: /docs/diseño/casos%20de%20uso/COM/CU-COM-005%20Calificación%20automática%20y%20gestión%20de%20etapa%20comercial.md
 [CU-EVT-001]: /docs/diseño/casos%20de%20uso/EVT/CU-EVT-001%20Registro%20en%20lista%20de%20espera.md
+[CU-EVT-003 Gestión de cupos de eventos]: /docs/diseño/casos%20de%20uso/EVT/CU-EVT-003%20Gestión%20de%20cupos%20de%20eventos.md

--- a/docs/diseño/casos de uso/EVT/CU-EVT-003 Gestión de cupos de eventos.md
+++ b/docs/diseño/casos de uso/EVT/CU-EVT-003 Gestión de cupos de eventos.md
@@ -1,25 +1,32 @@
-# CU-EVT-003 Sistema de inscripción
+# CU-EVT-003 Gestión de cupos de eventos
 
 ## Metadatos
 
 - ID: CU-EVT-003
 - Dominio: EVT
-- Nombre: Sistema de inscripción
+- Nombre: Gestión de cupos de eventos
 - Estado: Borrador
-- Versión: v0.2
+- Versión: v0.3
 - Fecha de creación: 2026-03-16
-- Última actualización: 2026-03-25
+- Última actualización: 2026-05-05
 - Responsable: Maximiliano Carrillo Alvarado
+- Última correción por: Isaac Ortiz
 - Issue relacionado: PSD-12
 - PR relacionado: #XX
 
 ## Objetivo
 
-El sistema debe apoyar al operador humano que trata con el Prospecto evitando mal funcionamiento como sobre inscribir a un evento con un cupo lleno y evitar errores humanos como inscribir alguien cuando un evento ya ha iniciado/finalizado
+Gestionar el estado de cupos durante el ciclo de inscripción de Cliente potencial en etapa Prospecto o SQL, asegurando la reserva temporal, bloqueo permanente tras confirmación de pago, y liberación de cupo en casos de no pago, abandono, cambio de evento o causas excepcionales.
 
 ## Alcance
 
-Sistema de gestión de inscripciones - subsistema de registro de Prospectos en eventos. Aplica al proceso de inscripción de Prospectos interesados a eventos específicos, con validaciones de disponibilidad, bloqueos temporales de cupos y confirmación de pago.
+Gestión centralizada de estados de cupo durante el ciclo de inscripción. Aplica a:
+
+- Reserva temporal de cupo cuando un Cliente potencial en etapa Prospecto manifiesta intención de inscribirse (disparado por CU-COM-002).
+- Bloqueo definitivo de cupo cuando un Cliente potencial en etapa SQL confirma el pago (disparado por operador humano vía CU-COM-001).
+- Liberación de cupo temporal cuando: no se confirma el pago en tiempo, el Cliente potencial abandona la conversación, o cambia de evento (disparado por CU-COM-002 o por vencimiento temporal).
+- Liberación de cupo bloqueado por causas excepcionales conforme a RF-EVT-04: ausencia confirmada, inscripción extemporánea, solicitud de reembolso (disparado por operador humano o CU-EVT-002).
+- Validaciones de disponibilidad de cupo para proteger contra sobreventa.
 
 ## RF relacionados
 
@@ -61,7 +68,7 @@ Un operador humano quiere inscribir a un Prospecto interesado a un evento en esp
 ### En fallo
 
 - El sistema no puede inscribir al Prospecto y, por ende, no queda registrado en el banco de contexto.
-- Si había una inscripción temporal, el sistema debe eliminarla del banco de contexto y notificar a los demás MQL. [CU-EVT-002]
+- Si había una inscripción temporal, el sistema debe eliminarla del banco de contexto y notificar a la lista de espera si hay al menos un cliente potencial en la lista. [CU-EVT-002]
 
 ## Flujo principal
 
@@ -69,7 +76,7 @@ Un operador humano quiere inscribir a un Prospecto interesado a un evento en esp
 2. El sistema debe verificar que el evento este disponible [RF-EVT-01]
 3. El sistema reserva la vacante [RF-EVT-02]
 4. El operador humano agrega la información personal del Prospecto al banco de contexto
-5. El debe bloquear la vacante temporalmente [RF-EVT-02]
+5. El sistema debe bloquear la vacante temporalmente [RF-EVT-02]
 6. El sistema notifica al operador humano que la inscripción ha sido exitosa
 7. El operador humano le informa al Prospecto que se ha quedado registrado y espera la confirmación de su pago en un periodo de tiempo
 
@@ -96,7 +103,16 @@ Un operador humano quiere inscribir a un Prospecto interesado a un evento en esp
 2. Al evento ya ha avanzado más de lo permitido para las inscripciones
 3. El sistema debe bloquear las inscripciones del evento en cuestión [RF-EVT-05]
 4. El sistema debe cancelar las inscripciones temporales [RF-EVT-04]
-5. Si quedan inscripciones temporales pasa al flujo A2, caso contrario el flujo termina
+5. El sistema libera las inscripciones temporales
+6. El flujo termina
+
+### A4. Abandono o cambio de evento
+
+1. El sistema detecta que el Cliente potencial abandona la conversación o cambia de evento (disparado por CU-COM-002)
+2. El sistema debe verificar la inscripción temporal [RF-EVT-02]
+3. El sistema debe quitar la información del Prospecto en el evento del banco de contexto y aumentar en 1 el cupo del evento
+4. El sistema debe notificar a la lista de espera [RF-EVT-03]
+5. El flujo termina
 
 ## Flujos de excepción
 
@@ -114,6 +130,14 @@ Un operador humano quiere inscribir a un Prospecto interesado a un evento en esp
 2. El sistema debe notificar al operador humano y borrar los datos que se hayan podido registrar para liberar la vacante
 3. El sistema debe permitir al operador humano reintentar la inscripción
 4. El sistema regresa al paso 1 si el agente lo vuelve a intentar, caso contrario el flujo acaba
+
+### E3. Liberación por causas excepcionales
+
+1. El operador humano o el sistema detecta una causa excepcional (ausencia confirmada, inscripción extemporánea, solicitud de reembolso) conforme a RF-EVT-04
+2. El sistema verifica la inscripción bloqueada
+3. El sistema libera el cupo bloqueado y actualiza el estado del evento
+4. El sistema notifica a la lista de espera si aplica [RF-EVT-03]
+5. El flujo termina
 
 ## Reglas de negocio / restricciones
 


### PR DESCRIPTION
Closes #73

## Tipo de cambio
- [x] Docs (documentación)
- [x] Fix (corrección)

## Contexto
Tres casos de uso del dominio COM y EVT presentaban desajustes en nombre, objetivo o alcance respecto a los procesos, definiciones y RF vigentes. CU-COM-001 no describía la orquestación real del sistema; CU-COM-002 usaba el término no normalizado "Persona interesada"; CU-EVT-003 estaba limitado a apoyar al operador en lugar de gestionar el ciclo completo de cupos.

## Cambios
- [x] CU-COM-001: redefinido Objetivo (orquestación bot↔humano por el sistema) y Alcance (ciclo completo: asignación, escalamiento, devolución, colas, auditoría)
- [x] CU-COM-002: renombrado a `Flujo de la conversación entre el Cliente potencial y el Bot`; todas las ocurrencias de "Persona interesada" reemplazadas por "Cliente potencial"; paso 12 corregido para activar CU-EVT-003 en lugar de CU-COM-003
- [x] CU-EVT-003: renombrado a `Gestión de cupos de eventos`; Objetivo y Alcance redefinidos para cubrir reserva temporal (Prospecto), bloqueo definitivo (SQL), liberación temporal y liberación por causas excepcionales (RF-EVT-04)

## Entregables / Rutas

- `docs/diseño/casos de uso/COM/CU-COM-001 Asignación de conversaciones de un bot a un operador humano.md`
- `docs/diseño/casos de uso/COM/CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot.md`
- `docs/diseño/casos de uso/EVT/CU-EVT-003 Gestión de cupos de eventos.md`

## Notas y riesgos
- CU-EVT-003 es ahora el CU central para gestión de cupos; cualquier CU que mencione flujos de cupo debe referenciarlo explícitamente.
- CU-COM-001 aún no incluye la activación de CU-EVT-003 para bloquear cupo en confirmación de pago SQL — pendiente como issue independiente para no solapar con #76 (PSD-26).
- Los BPMN referenciados (BPMN-COM-001, BPMN-EVT-003) no se actualizan en este PR; quedan bloqueados por #72 (PSD-22).