### PR TITLE
PSD-28 [docs] crear ddr 02 decisiones arquitectónicas del sistema orquestador

### DIFF
--- a/docs/analisis/modelos del problema/casos de uso/COM/CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot.md
+++ b/docs/analisis/modelos del problema/casos de uso/COM/CU-COM-002 Flujo de la conversación entre el Cliente potencial y el Bot.md
@@ -78,8 +78,8 @@ El sistema ha asignado un Bot a la conversación del Cliente potencial en el can
 8. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener fechas y horarios del Evento y el Bot los presenta. [RF-COM-06]
 9. El Cliente potencial muestra interés en inscribirse con preguntas clave como métodos de pago y procesos de inscripción.
 10. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener la disponibilidad de cupo del Evento. [RF-EVT-01]
-11. Haya o no haya cupo, se activa el [CU-COM-005 Gestión de etapa comercial].
-12. Si hay cupo se activa [CU-EVT-003 Gestión de cupos de eventos] para reservar un cupo temporal para el Cliente potencial. [RF-EVT-02]
+11. Haya o no haya cupo, se activa el [CU-COM-005 Gestión de etapa comercial] para actualizar la etapa.
+12. Si la etapa resultante es **Prospecto** y hay cupo, se activa [CU-EVT-003 Gestión de cupos de eventos] para **reservar un cupo temporal** para el Cliente potencial. [RF-EVT-02]
 13. Se activa [CU-COM-003 Gestión de bancos de contexto] para obtener información de métodos de pago y proceso de inscripción, y el Bot la presenta al Cliente potencial. [RF-COM-04]
 14. El Bot detecta que el cliente potencial ha enviado mensajes que detonan la necesidad de confirmación de pago por parte de un operador humano por lo tanto se activa el [CU-COM-005 Gestión de etapa comercial].
 15. El Bot informa que será transferido a un operador humano y se activa el flujo de [CU-COM-001 Asignación de conversaciones de un bot a un operador humano].

--- a/docs/analisis/modelos del problema/casos de uso/COM/CU-COM-005 Calificación automática y gestión de etapa comercial.md
+++ b/docs/analisis/modelos del problema/casos de uso/COM/CU-COM-005 Calificación automática y gestión de etapa comercial.md
@@ -22,6 +22,8 @@ Gestionar la etapa comercial de la Persona interesada y calcular su calificació
 
 Aplica a toda interacción gestionada por el Bot desde el inicio de la conversación hasta el escalamiento. Es invocado por CU-COM-002 y CU-COM-001 en cada punto donde se produzca un evento de transición de etapa o se requiera actualizar la calificación.
 
+Este CU gestiona **transiciones automáticas solo hasta SQL**. La etapa **Cierre** existe como etapa comercial válida con resultado **Ganado/Perdido**, pero se alcanza **manualmente** tras intervención humana y no es una transición automática descrita por este CU.
+
 ## RF relacionados
 
 - [RF-COM-02]

--- a/docs/analisis/modelos del problema/casos de uso/EVT/CU-EVT-003 Gestión de cupos de eventos.md
+++ b/docs/analisis/modelos del problema/casos de uso/EVT/CU-EVT-003 Gestión de cupos de eventos.md
@@ -25,7 +25,7 @@ Gestión centralizada de estados de cupo durante el ciclo de inscripción. Aplic
 - Reserva temporal de cupo cuando un Cliente potencial en etapa Prospecto manifiesta intención de inscribirse (disparado por CU-COM-002).
 - Bloqueo definitivo de cupo cuando un Cliente potencial en etapa SQL confirma el pago (disparado por operador humano vía CU-COM-001).
 - Liberación de cupo temporal cuando: no se confirma el pago en tiempo, el Cliente potencial abandona la conversación, o cambia de evento (disparado por CU-COM-002 o por vencimiento temporal).
-- Liberación de cupo bloqueado por causas excepcionales conforme a RF-EVT-04: ausencia confirmada, inscripción extemporánea, solicitud de reembolso (disparado por operador humano o CU-EVT-002).
+- Liberación de cupo bloqueado por causas excepcionales conforme a RF-EVT-04: ausencia confirmada, inscripción extemporánea, solicitud de reembolso (disparado por [CU-EVT-002]).
 - Validaciones de disponibilidad de cupo para proteger contra sobreventa.
 
 ## RF relacionados
@@ -41,61 +41,68 @@ Gestión centralizada de estados de cupo durante el ciclo de inscripción. Aplic
 
 ### Actor principal
 
-- Operador humano, quien estará en contacto constantemente con el Prospecto ayudandole a inscribirse
+- Sistema (Orquestador), responsable de ejecutar operaciones de cupo de forma segura y atómica.
 
 ### Actores secundarios
 
-- Banco de contexto (gestiona datos de eventos, inscripciones y lista de espera)
-- Persona interesada
+- Bot (emite señales y solicita operaciones desde CU-COM-002)
+- Operador humano (valida pago y solicita bloqueo definitivo en SQL vía CU-COM-001)
+- Banco de contexto (gestiona datos de eventos, reservas e inscripciones)
+- Cliente potencial
 
 ## Disparador
 
-Un operador humano quiere inscribir a un Prospecto interesado a un evento en especifico
+El Orquestador recibe una solicitud de operación de cupo derivada del flujo comercial:
+
+- **Reserva temporal**: CU-COM-002 invoca este CU cuando, tras ejecutar CU-COM-005, la etapa queda en **Prospecto** y se requiere proteger el cupo.
+- **Bloqueo definitivo**: un Operador humano valida el pago en etapa **SQL** y CU-COM-001 invoca este CU para bloquear definitivamente.
+- **Liberación**: CU-COM-002 (abandono/cambio de evento), vencimiento de la reserva temporal o [CU-EVT-002] (causas excepcionales) solicitan liberar.
 
 ## Precondiciones
 
-- El Prospecto ya ha proporcionado sus datos personales
-- Ya ha pasado por el proceso automatizado
-- El Prospecto es conciente de la información del evento
+- Existe un Evento vigente en el banco de contexto.
+- La conversación ya alcanzó la etapa comercial requerida por la operación:
+- **Prospecto** para reservar/liberar una reserva temporal.
+- **SQL** para bloquear definitivamente tras validación de pago.
+- El Cliente potencial ya interactuó con el Bot y proporcionó los datos mínimos de contacto en CU-COM-002.
 
 ## Postcondiciones
 
 ### En éxito
 
-- El Prospecto queda inscrito en el banco de contexto.
-- El operador humano inscribe al Prospecto al evento y el sistema se encarga de que la inscripción sea permanente.
+- Si se solicitó **reserva temporal**, queda registrada una reserva asociada al Cliente potencial y al Evento con un TTL.
+- Si se solicitó **bloqueo definitivo**, el cupo queda bloqueado de forma permanente y la inscripción queda confirmada.
+- Si se solicitó **liberación**, el cupo vuelve a estar disponible y, cuando aplica, se activa la notificación a lista de espera.
 
 ### En fallo
 
-- El sistema no puede inscribir al Prospecto y, por ende, no queda registrado en el banco de contexto.
-- Si había una inscripción temporal, el sistema debe eliminarla del banco de contexto y notificar a la lista de espera si hay al menos un cliente potencial en la lista. [CU-EVT-002]
+- El Sistema no puede ejecutar la operación solicitada (por ejemplo, evento lleno, conflicto por concurrencia o precondición de etapa no satisfecha).
+- No se altera el estado del cupo.
 
 ## Flujo principal
 
-1. El operador humano inicia la inscripción del Prospecto
-2. El sistema debe verificar que el evento este disponible [RF-EVT-01]
-3. El sistema reserva la vacante [RF-EVT-02]
-4. El operador humano agrega la información personal del Prospecto al banco de contexto
-5. El sistema debe bloquear la vacante temporalmente [RF-EVT-02]
-6. El sistema notifica al operador humano que la inscripción ha sido exitosa
-7. El operador humano le informa al Prospecto que se ha quedado registrado y espera la confirmación de su pago en un periodo de tiempo
+1. CU-COM-002 solicita al Sistema reservar un cupo temporal para el Evento al confirmar que la etapa comercial quedó en **Prospecto** (vía CU-COM-005).
+2. El Sistema verifica disponibilidad de cupo para el Evento. [RF-EVT-01]
+3. El Sistema crea una **reserva temporal** del cupo asociada al Cliente potencial y al Evento (bloqueo atómico y con TTL). [RF-EVT-02]
+4. El Sistema confirma a CU-COM-002 que la reserva temporal fue creada.
+5. El flujo termina.
 
 ## Flujos alternos
 
 ### A1. El Prospecto no paga a tiempo
 
-1. El sistema detecta que el Prospecto no ha hecho el pago correspondiente (información dada por el operador humano)
-2. El sistema debe verificar la inscripción temporal [RF-EVT-02]
-3. El sistema debe quitar la información del Prospecto en el evento del banco de contexto y aumentar en 1 el cupo del evento
-4. El sistema debe notificar a la lista de espera [RF-EVT-03]
-5. El flujo termina
+1. El Sistema detecta el vencimiento de la reserva temporal (TTL).
+2. El Sistema verifica la reserva temporal activa. [RF-EVT-02]
+3. El Sistema libera la reserva y actualiza el cupo del Evento. [RF-EVT-02]
+4. El Sistema notifica a la lista de espera cuando aplica. [RF-EVT-03]
+5. El flujo termina.
 
 ### A2. El Prospecto paga a tiempo
 
-1. El sistema detecta que el Prospecto ha hecho el pago correspondiente
-2. El sistema debe verificar la inscripción temporal
-3. El sistema debe volver permanente la inscripción [RF-EVT-04]
-4. El flujo acaba
+1. Un Operador humano valida el pago del Cliente potencial ya en etapa **SQL** (CU-COM-001).
+2. CU-COM-001 solicita al Sistema bloquear definitivamente el cupo asociado a la reserva temporal.
+3. El Sistema verifica la reserva temporal y realiza el **bloqueo definitivo** del cupo/inscripción. [RF-EVT-04]
+4. El flujo termina.
 
 ### A3. El evento ya ha iniciado
 
@@ -104,40 +111,39 @@ Un operador humano quiere inscribir a un Prospecto interesado a un evento en esp
 3. El sistema debe bloquear las inscripciones del evento en cuestión [RF-EVT-05]
 4. El sistema debe cancelar las inscripciones temporales [RF-EVT-04]
 5. El sistema libera las inscripciones temporales
-6. El flujo termina
+6. El flujo termina.
 
 ### A4. Abandono o cambio de evento
 
-1. El sistema detecta que el Cliente potencial abandona la conversación o cambia de evento (disparado por CU-COM-002)
-2. El sistema debe verificar la inscripción temporal [RF-EVT-02]
-3. El sistema debe quitar la información del Prospecto en el evento del banco de contexto y aumentar en 1 el cupo del evento
-4. El sistema debe notificar a la lista de espera [RF-EVT-03]
-5. El flujo termina
+1. CU-COM-002 solicita liberar la reserva temporal cuando el Cliente potencial abandona la conversación o cambia de Evento.
+2. El Sistema verifica la reserva temporal activa. [RF-EVT-02]
+3. El Sistema libera la reserva y actualiza el cupo del Evento. [RF-EVT-02]
+4. El Sistema notifica a la lista de espera cuando aplica. [RF-EVT-03]
+5. El flujo termina.
 
 ## Flujos de excepción
 
 ### E1. El evento está lleno
 
 1. En el paso 2, si el evento está lleno
-2. El sistema o el operador humano validan la inscripción y detienen/rechazan el proceso por falta de cupo
-3. El operador humano debe preguntarle al Prospecto si desea que lo pongan en la lista de espera
-4. Si el Prospecto acepta se le agrega [RF-EVT-06], caso contrario no se le agrega
-5. El flujo termina
+2. El Sistema rechaza la reserva temporal por falta de cupo.
+3. CU-COM-002 puede invocar el registro en lista de espera cuando el Cliente potencial esté en etapa Prospecto. [RF-EVT-06]
+4. El flujo termina.
 
 ### E2. Falla la inscripción/registro de datos
 
-1. En el paso 4 cuando el operador humano trata de agregar la información esta falla
-2. El sistema debe notificar al operador humano y borrar los datos que se hayan podido registrar para liberar la vacante
-3. El sistema debe permitir al operador humano reintentar la inscripción
-4. El sistema regresa al paso 1 si el agente lo vuelve a intentar, caso contrario el flujo acaba
+1. Ocurre un error al crear/liberar/bloquear una reserva por falla de persistencia o conflicto de concurrencia.
+2. El Sistema revierte cualquier cambio parcial (si aplica) y no altera el cupo final.
+3. El Sistema notifica el error al flujo invocador.
+4. El flujo termina.
 
 ### E3. Liberación por causas excepcionales
 
-1. El operador humano o el sistema detecta una causa excepcional (ausencia confirmada, inscripción extemporánea, solicitud de reembolso) conforme a RF-EVT-04
-2. El sistema verifica la inscripción bloqueada
-3. El sistema libera el cupo bloqueado y actualiza el estado del evento
-4. El sistema notifica a la lista de espera si aplica [RF-EVT-03]
-5. El flujo termina
+1. [CU-EVT-002] solicita liberar un cupo bloqueado por una causa excepcional (ausencia confirmada, inscripción extemporánea, solicitud de reembolso) conforme a RF-EVT-04.
+2. El Sistema verifica la inscripción/cupo bloqueado.
+3. El Sistema libera el cupo bloqueado y actualiza el estado del Evento.
+4. El Sistema notifica a la lista de espera si aplica. [RF-EVT-03]
+5. El flujo termina.
 
 ## Reglas de negocio relacionadas
 
@@ -170,13 +176,13 @@ Referencia:
 
 ## Observaciones
 
-- El operador humano guía el proceso mientras el sistema aplica validaciones de cupo y temporalidad.
-- El caso contempla transición entre inscripción temporal y permanente según confirmación de pago.
+- La **reserva temporal** se ejecuta automáticamente por el Sistema al llegar a etapa Prospecto (CU-COM-002 + CU-COM-005).
+- El **bloqueo definitivo** ocurre únicamente tras validación de pago por un Operador humano en SQL.
 
 ## Trazabilidad
 
 - RF: RF-EVT-01, RF-EVT-02, RF-EVT-03, RF-EVT-04, RF-EVT-05, RF-EVT-06
-- CU: CU-EVT-002
+- CU: [CU-EVT-002]
 
 [CU-EVT-002]: /docs/analisis/modelos%20del%20problema/casos%20de%20uso/EVT/CU-EVT-002%20Gestión%20de%20cancelación.md
 [RF-EVT-01]: /docs/analisis/requerimientos/funcionales/EVT/RF-EVT-01%20Verificacion%20de%20disponibilidad%20de%20cupo.md

--- a/docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md
+++ b/docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md
@@ -72,7 +72,7 @@ La estrategia v2.0 refuerza y operacionaliza el diagnóstico de DDR-01. La sigui
 | Evitar que estados operativos (reserva/cupo/inscripción/cancelación) se modelen como etapas comerciales | **Validado** | Las operaciones EVT no escriben etapa; si un cambio comercial aplica, debe ocurrir por señal de etapa (CU-COM-005). |
 | Lista de espera: orden por calificación, FIFO como desempate | **Validado** | `WaitingListService` aplica score DESC y FIFO para empates (coherente con CU-EVT-001 y estrategia v2.0). |
 | Privacidad/consentimiento: ubicarlo de forma normativa y no bloquear indebidamente consultas | **Validado con precisión** | Se adopta CU-COM-004: el sistema muestra avisos legales y registra consentimiento tácito al primer mensaje. Antes de consentir, no se capturan datos ni se habilitan tool calls con escritura. |
-| Cierre como etapa con resultado (Ganado/Perdido), no como etapas inventadas | **Parcial / pendiente** | Se mantiene el término "Cierre" como etapa, pero el modelado del resultado (Ganado/Perdido) queda pendiente de alineación documental (ver contradicciones/DDRs futuros). |
+| Cierre como etapa con resultado (Ganado/Perdido), no como etapas inventadas | **Validado con delimitación** | **CIERRE** existe como etapa comercial final con resultado **Ganado/Perdido**; sin embargo, se alcanza **manualmente** tras intervención humana (no es una transición automática del bot ni de CU-COM-005). |
 
 ---
 

--- a/docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md
+++ b/docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md
@@ -1,0 +1,327 @@
+# DDR-02 Decisiones arquitectónicas del orquestador
+
+## Metadatos
+
+- ID: DDR-02
+- Título: Decisiones arquitectónicas del orquestador
+- Estado: Propuesto
+- Fecha: 2026-05-19
+- Responsable: Maximiliano Carrillo Alvarado
+- Referencias: [DDR-01](/docs/diseño/decisiones/DDR-01-impacto-de-rf-com-02-en-los-casos-de-uso.md), [Estrategia de implementación v2.0](/docs/soporte/utils/estrategia%20de%20implementacion%20chat.md)
+
+---
+
+## Problemática
+
+DDR-01 sentó las bases de la separación entre **etapa comercial**, **calificación** y **estado operativo**. Desde entonces se completó la **Estrategia de implementación v2.0**, que introduce el principio: **"El bot emite señales. El sistema ejecuta operaciones de dominio."**
+
+DDR-01 sigue siendo vigente, pero incompleto desde la perspectiva del orquestador: aún falta consolidar (a) el principio central como contrato técnico, (b) el mapeo de servicios del orquestador a casos de uso, (c) la justificación de monorepo, y (d) el contrato oficial de tool calls.
+
+---
+
+## Objetivo
+
+Documentar las decisiones arquitectónicas del orquestador, **validando DDR-01** y extendiéndolo con:
+
+1. Principio arquitectónico central.
+2. Mapeo de 14 servicios a casos de uso (trazabilidad 1:1 por servicio).
+3. Justificación técnica de monorepo (docs + código accesibles para AI).
+4. Contrato oficial de 8 tool calls con firmas TypeScript y semántica.
+5. Decisiones de stack: TypeScript + NestJS + Prisma + Redis + BullMQ + Anthropic SDK.
+
+---
+
+## Alcance
+
+- Este DDR define **contratos y límites** del orquestador y su interacción con el Bot.
+- No redefine RF ni CU; los **usa como fuente de verdad** y fija consecuencias de implementación.
+
+---
+
+## Decisión 1 — Principio arquitectónico central
+
+> **El bot emite señales. El sistema ejecuta operaciones de dominio.**
+
+### Enunciado
+
+- El Bot **no** accede a base de datos.
+- El Bot **no** ejecuta transiciones comerciales ni operaciones operativas.
+- El Bot **solo** emite señales y solicita operaciones **vía tool calls**.
+- El Orquestador valida precondiciones (etapa, consentimiento, idempotencia, tenant) y ejecuta operaciones mediante servicios internos.
+
+### Justificación
+
+Este principio evita la raíz del problema descrito en DDR-01: mezclar responsabilidades del Bot con operaciones de dominio (etapas, cupos, lista de espera, escalamiento). También impone una frontera explícita de seguridad: el Bot no necesita credenciales de persistencia.
+
+### Consecuencias
+
+- Toda operación con efectos (persistencia, reserva de cupo, escalamiento) queda detrás de tool calls.
+- Se vuelve obligatorio definir un contrato de tool calls estable y versionable.
+
+---
+
+## Decisión 2 — Validación de DDR-01 respecto a Estrategia v2.0
+
+La estrategia v2.0 refuerza y operacionaliza el diagnóstico de DDR-01. La siguiente tabla valida o refuta sus puntos relevantes para el orquestador.
+
+| Punto (DDR-01) | Resultado | Decisión en DDR-02 |
+| --- | --- | --- |
+| Separar estrictamente etapa comercial, calificación y estado operativo | **Validado** | Se modelan como concerns separados: `CommercialStageService` (etapa), `ScoringService` (calificación), `QuotaService`/`WaitingListService`/`CancellationService` (operativo). |
+| RF-COM-02 como núcleo rector del sistema comercial | **Validado** | El orquestador considera CU-COM-005 como fuente de transiciones y precondiciones para operaciones EVT. |
+| La calificación prioriza; no actualiza etapa | **Validado** | La tool call `emit_stage_signal` actualiza etapa; la calificación se recalcula como efecto separado y solo influye en priorización (por ejemplo, lista de espera). |
+| Evitar que estados operativos (reserva/cupo/inscripción/cancelación) se modelen como etapas comerciales | **Validado** | Las operaciones EVT no escriben etapa; si un cambio comercial aplica, debe ocurrir por señal de etapa (CU-COM-005). |
+| Lista de espera: orden por calificación, FIFO como desempate | **Validado** | `WaitingListService` aplica score DESC y FIFO para empates (coherente con CU-EVT-001 y estrategia v2.0). |
+| Privacidad/consentimiento: ubicarlo de forma normativa y no bloquear indebidamente consultas | **Validado con precisión** | Se adopta CU-COM-004: el sistema muestra avisos legales y registra consentimiento tácito al primer mensaje. Antes de consentir, no se capturan datos ni se habilitan tool calls con escritura. |
+| Cierre como etapa con resultado (Ganado/Perdido), no como etapas inventadas | **Parcial / pendiente** | Se mantiene el término "Cierre" como etapa, pero el modelado del resultado (Ganado/Perdido) queda pendiente de alineación documental (ver contradicciones/DDRs futuros). |
+
+---
+
+## Decisión 3 — Mapeo de servicios (14) a casos de uso
+
+Cada servicio del orquestador se ancla a **un caso de uso** (1:1 por servicio) para trazabilidad. Cuando un servicio es transversal, se ancla al CU donde su participación es obligatoria para iniciar el flujo (punto de integración más temprano).
+
+| Servicio | CU (1:1) | Responsabilidad |
+| --- | --- | --- |
+| `MessageRouter` | CU-COM-001 | Recibe webhook del canal, crea conversación, resuelve tenant, asigna bot u operador. |
+| `AgentRunner` | CU-COM-002 | Ejecuta el run loop del LLM: mensaje → tool calls → respuesta. |
+| `HandoffManager` | CU-COM-001 | Gestiona transición bot↔operador y colas de atención humana. |
+| `ConsentService` | CU-COM-004 | Muestra avisos legales vía banco de contexto y registra consentimiento tácito al primer mensaje. |
+| `CommercialStageService` | CU-COM-005 | Máquina de estados de etapa comercial; procesa señales emitidas por el bot. |
+| `ScoringService` | CU-COM-005 | Recalcula calificación (0–20), detecta exploits y alimenta priorización. |
+| `ContextBankService` | CU-COM-003 | Puerta única de lectura/escritura controlada a bancos de contexto (general y evento). |
+| `QuotaService` | CU-EVT-003 | Reserva temporal, liberación y bloqueo definitivo de cupos con bloqueo atómico. |
+| `WaitingListService` | CU-EVT-001 | Alta y consulta de lista de espera; orden por calificación y FIFO como desempate. |
+| `CancellationService` | CU-EVT-002 | Cancelación pre-inicio; libera cupo; dispara notificación al siguiente elegible cuando aplica. |
+| `NotificationService` | CU-COM-006 | Notificaciones outbound de reactivación; reutiliza el canal y respeta anti-spam. |
+| `AuditLogService` | CU-COM-001 | Log append-only de transacciones con `conversation_id` y `transaction_id`. |
+| `TenantConfigService` | CU-COM-001 | Resuelve configuración y credenciales por `tenantId` antes de ejecutar cualquier flujo. |
+| `ConversationSessionStore` | CU-COM-002 | Historial activo en Redis (TTL) y checkpoint a DB al cerrar conversación (RNF-04). |
+
+Notas:
+
+- La trazabilidad a RF (cuando aplica) se conserva en los CU; este DDR fija únicamente el ancla 1:1 de cada servicio.
+
+---
+
+## Decisión 4 — Monorepo (docs + código)
+
+### Decisión
+
+Se adopta **monorepo** como estrategia técnica para mantener, en el mismo repositorio:
+
+- documentación de análisis y diseño (RF/CU/RN/DDR/BPMN), y
+- implementación del orquestador.
+
+### Justificación técnica
+
+- **Contrato verificable**: el orquestador debe implementar literalmente contratos documentales (CU/RF/RN). Separar repositorios aumenta el riesgo de divergencia.
+- **Trazabilidad por PR**: una PR puede actualizar un CU y el código que lo implementa en el mismo cambio.
+- **Accesible para AI**: el asistente puede leer docs y código sin cambiar de repositorio; reduce errores de implementación por “context switching”.
+- **CI unificado**: validaciones de Markdown, enlaces, y build/test del código viven en el mismo pipeline.
+
+### Costos / riesgos
+
+- Repo más grande y con más permisos; requiere disciplina de carpetas.
+- Requiere reglas claras de ownership (CODEOWNERS) para evitar que cambios de código rompan documentación y viceversa.
+
+---
+
+## Decisión 5 — Contrato oficial de tool calls (8) con TypeScript
+
+### Propósito
+
+Las tool calls son el **único** canal por el cual el Bot puede:
+
+- leer bancos de contexto,
+- emitir señales comerciales, y
+- solicitar operaciones EVT u operativas (cupo, lista de espera, escalamiento).
+
+### Principios del contrato
+
+1. **Idempotencia obligatoria** para tool calls con efectos repetibles.
+2. **Validación por etapa** (el orquestador rechaza operaciones fuera de etapa).
+3. **Errores de dominio tipados** (para mensajes claros y trazables).
+4. **Multi-tenant explícito**: el `tenantId` no viaja en la tool call; lo resuelve el orquestador por conversación.
+
+### Tipos base
+
+```ts
+export type ToolCallOk<T> = { ok: true; data: T };
+
+export type ToolCallErrorCode =
+	| 'VALIDATION_ERROR'
+	| 'CONSENT_REQUIRED'
+	| 'STAGE_PRECONDITION_FAILED'
+	| 'NOT_FOUND'
+	| 'CONFLICT'
+	| 'RATE_LIMITED'
+	| 'TEMPORARY_UNAVAILABLE'
+	| 'INTERNAL_ERROR';
+
+export type ToolCallErr = {
+	ok: false;
+	error: {
+		code: ToolCallErrorCode;
+		message: string; // humano-legible; apto para mostrar al usuario final
+		retryable: boolean;
+		details?: Record<string, unknown>;
+	};
+};
+
+export type ToolCallResult<T> = ToolCallOk<T> | ToolCallErr;
+
+export type CommercialStage = 'LEAD' | 'MQL' | 'PROSPECTO' | 'SQL' | 'CIERRE';
+
+export type StageSignal =
+	| 'conversacion_iniciada'
+	| 'datos_de_contacto_completados'
+	| 'pregunta_de_inscripcion_detectada'
+	| 'confirmacion_de_pago_pendiente'
+	| 'evento_cambiado';
+
+export type IdempotencyKey = string;
+```
+
+### Tool calls (8)
+
+```ts
+// 1) Banco de contexto general (CU-COM-003)
+export type GetGeneralContextInput = { fields?: string[] };
+export type GetGeneralContextOutput = {
+	context: Record<string, unknown>;
+	updatedAt: string; // ISO-8601
+};
+export function get_general_context(
+	input: GetGeneralContextInput,
+): Promise<ToolCallResult<GetGeneralContextOutput>>;
+
+// 2) Banco de contexto de evento (CU-COM-003)
+export type GetEventContextInput = { eventId: string; fields?: string[] };
+export type GetEventContextOutput = {
+	eventId: string;
+	context: Record<string, unknown>;
+	updatedAt: string; // ISO-8601
+};
+export function get_event_context(
+	input: GetEventContextInput,
+): Promise<ToolCallResult<GetEventContextOutput>>;
+
+// 3) Señal de transición comercial (CU-COM-005)
+export type EmitStageSignalInput = {
+	signal: StageSignal;
+	eventId?: string; // requerido cuando la señal depende de evento (p.ej., pregunta_de_inscripcion_detectada, evento_cambiado)
+};
+export type EmitStageSignalOutput = {
+	previousStage: CommercialStage;
+	currentStage: CommercialStage;
+	score?: number; // 0-20 (si se recalcula en el mismo paso)
+};
+export function emit_stage_signal(
+	input: EmitStageSignalInput,
+): Promise<ToolCallResult<EmitStageSignalOutput>>;
+
+// 4) Reservar cupo temporal (CU-EVT-003)
+export type ReserveQuotaInput = { eventId: string; idempotencyKey: IdempotencyKey };
+export type ReserveQuotaOutput = { reservationId: string; expiresAt: string };
+export function reserve_quota(
+	input: ReserveQuotaInput,
+): Promise<ToolCallResult<ReserveQuotaOutput>>;
+
+// 5) Liberar cupo reservado (CU-EVT-003)
+export type ReleaseQuotaInput = { eventId: string };
+export type ReleaseQuotaOutput = { released: boolean };
+export function release_quota(
+	input: ReleaseQuotaInput,
+): Promise<ToolCallResult<ReleaseQuotaOutput>>;
+
+// 6) Bloquear cupo definitivo post-pago (CU-EVT-003)
+export type BlockQuotaInput = { eventId: string; idempotencyKey: IdempotencyKey };
+export type BlockQuotaOutput = { blocked: boolean };
+export function block_quota(
+	input: BlockQuotaInput,
+): Promise<ToolCallResult<BlockQuotaOutput>>;
+
+// 7) Registro en lista de espera (CU-EVT-001)
+export type RegisterWaitingListInput = { eventId: string; idempotencyKey: IdempotencyKey };
+export type RegisterWaitingListOutput = { position: number };
+export function register_waiting_list(
+	input: RegisterWaitingListInput,
+): Promise<ToolCallResult<RegisterWaitingListOutput>>;
+
+// 8) Solicitar escalamiento a humano (CU-COM-001)
+export type RequestHumanHandoffInput = {
+	reason:
+		| 'pago_pendiente'
+		| 'no_resuelto'
+		| 'peticion_del_usuario'
+		| 'politica'
+		| 'fallo_tecnico';
+};
+export type RequestHumanHandoffOutput = { handoffId: string; queued: boolean };
+export function request_human_handoff(
+	input: RequestHumanHandoffInput,
+): Promise<ToolCallResult<RequestHumanHandoffOutput>>;
+```
+
+### Semántica obligatoria (resumen)
+
+- `emit_stage_signal`
+	- El orquestador decide la transición según CU-COM-005.
+	- Si `signal` implica operación EVT (por ejemplo, intención de inscripción), el orquestador puede encadenar la operación correspondiente (p. ej., reservar cupo) pero **solo** si la etapa resultante lo permite.
+- `reserve_quota`
+	- Precondición: etapa comercial resultante debe ser **PROSPECTO**.
+	- Idempotencia: el mismo `idempotencyKey` debe producir el mismo resultado (dedupe).
+- `block_quota`
+	- Precondición: etapa comercial debe ser **SQL** (confirmación pendiente y control humano).
+- `register_waiting_list`
+	- Precondición: etapa comercial debe ser **PROSPECTO** y cupo no disponible.
+
+---
+
+## Decisión 6 — Stack tecnológico
+
+Se adopta el stack recomendado en la estrategia v2.0 por su alineación directa con tool use y multi-tenant.
+
+### Lenguaje: TypeScript (Node.js 20+)
+
+- Facilita tool use con types completos.
+- Simplifica el run loop del agente con async/await.
+
+### Framework: NestJS
+
+- DI y modularidad para reflejar bounded contexts (conversation/commercial/events/tenant).
+- Pipes/guards/DTO validation para contratos seguros.
+
+### Persistencia: Prisma
+
+- Migraciones versionadas, schema como contrato.
+- Type-safe queries y soporte natural a multi-tenant por conexión resuelta por `TenantConfigService`.
+
+### Cache/cola: Redis + BullMQ
+
+- Redis para `ConversationSessionStore` (RNF-04) e idempotencia.
+- BullMQ para expiración de reservas, notificaciones y trabajos asíncronos.
+
+### LLM: Anthropic SDK (`@anthropic-ai/sdk`)
+
+- Tool use como contrato primario.
+- Permite inyección de API key y modelo por tenant.
+
+---
+
+## Consecuencias y reglas de implementación (para el orquestador)
+
+1. El orquestador debe procesar tool calls como una **máquina de estados**: validar → deduplicar → ejecutar → auditar.
+2. Toda tool call con efectos debe generar `transaction_id` y registrar auditoría.
+3. La política de “tool calls permitidas por etapa” debe ser explícita (por ejemplo: ocultar `block_quota` hasta SQL).
+
+---
+
+## Trazabilidad
+
+- DDR relacionado: [DDR-01](/docs/diseño/decisiones/DDR-01-impacto-de-rf-com-02-en-los-casos-de-uso.md)
+- Estrategia: [Estrategia de implementación v2.0](/docs/soporte/utils/estrategia%20de%20implementacion%20chat.md)
+- CU clave:
+	- CU-COM-001, CU-COM-002, CU-COM-003, CU-COM-004, CU-COM-005, CU-COM-006
+	- CU-EVT-001, CU-EVT-002, CU-EVT-003
+


### PR DESCRIPTION
<!--
Pull Request Template
- Manténlo concreto.
- Incluye trazabilidad obligatoria a Issue.
-->

Closes #83

## Tipo de cambio
- [x] Docs (documentación)
- [ ] Feature (funcionalidad/código)
- [ ] Fix (corrección)
- [ ] Chore (mantenimiento)

## Contexto
DDR-01 estableció la separación entre etapa comercial, calificación y estado operativo, pero quedó incompleto para guiar la implementación del orquestador. Con la estrategia v2.0 ya definida, faltaba consolidar en DDR-02: el principio “Bot emite señales → Sistema ejecuta”, el mapeo de servicios a CU, la justificación de monorepo y el contrato formal de tool calls para tool use.

## Cambios
- [x] Se redactó DDR-02 con decisiones arquitectónicas del orquestador y validación/refutación explícita de puntos de DDR-01 contra estrategia v2.0.
- [x] Se documentó el mapeo 14 servicios → CU (trazabilidad 1:1 por servicio) y la justificación técnica de monorepo.
- [x] Se definió el contrato oficial de 8 tool calls con firmas TypeScript y semántica (idempotencia, precondiciones por etapa, errores tipados) y se registraron contradicciones detectadas para follow-up sin modificar otros artefactos.

## Entregables / Rutas
- `docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md](docs/diseño/decisiones/DDR-02-decisiones-arquitectonicas-del-orquestador.md`
- `docs/diseño/decisiones/contradicciones-DDR02.md](docs/diseño/decisiones/contradicciones-DDR02.md`