### PR TITLE
#108 PSD-41: Análisis de código rama claude-develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.claude/
 resultado.md
 notas.md
 __pycache__/

--- a/docs/analisis-codigo/01-configuracion-prisma-demo.md
+++ b/docs/analisis-codigo/01-configuracion-prisma-demo.md
@@ -1,0 +1,76 @@
+# 01 - Configuración, Prisma y demo
+
+## Cómo arranca la aplicación
+
+- El punto de entrada es `src/main.ts`. Ahí se crea la aplicación, se activan reglas de seguridad y validación, se configura CORS para permitir llamadas desde la GUI de demo y se monta la documentación de la API en `/api/docs`.
+- El módulo raíz es `src/app.module.ts`. Ahí se registran los módulos principales (tenants, conversaciones, eventos, notificaciones, auditoría, canales) y también la integración con Redis (para colas) y la configuración global del proyecto.
+
+## Qué guarda la base de datos
+
+- Lead: un posible cliente, con teléfono, email y su estado comercial.
+- Conversation: la sesión entre el lead y el bot o un operador.
+- Reservation y WaitingListEntry: reservas y listas de espera para eventos/cursos.
+- Event: la información de cursos o actividades (nombre, fechas, cupos, datos de contexto).
+- AuditLog y StageHistory: registros de acciones y cambios de estado para trazabilidad.
+- TenantConfig / TenantCredential: configuración y credenciales por cliente (guardadas de forma segura en la DB del sistema).
+
+## Qué contratos y formatos usa el código
+
+- La API espera mensajes con campos claros: `tenantId`, `channelType`, `channelId`, `messageId`, `text`, `timestamp`. Eso es lo que envían la GUI y el bridge de WhatsApp.
+- Hay DTOs (definiciones tipo) que documentan estas formas de mensaje y los tool calls (reservas, señales de etapa, etc.).
+
+## Qué hace la carpeta `demo/` (flujos principales)
+
+- `demo/seed/seed.js`: crea un tenant de demo, guarda credenciales y carga eventos desde `demo/eventos/*.json`. Al final envía un mensaje de prueba al orquestador para verificar que todo responde.
+- `demo/open-wa-bridge/index.js`: conecta WhatsApp con el orquestador. Recibe mensajes de WhatsApp y los reenvía al orquestador; también puede recibir respuestas desde el orquestador para enviarlas a usuarios.
+- `demo/gui/*`: una interfaz estática que consume la API del orquestador y muestra estadísticas, logs y la conversación.
+- `demo/docker-compose.yml` y `demo/start.sh`: scripts para levantar la demo completa (Postgres, Redis, orquestador, GUI y, opcionalmente, el bridge de WhatsApp). `start.sh` es interactivo: pide la key de Claude y ejecuta el seed dentro del contenedor.
+
+## Riesgos y cosas a tener en cuenta
+
+- La configuración está repartida: la GUI y el bridge usan valores codificados, por lo que es fácil desincronizarlos.
+- `start.sh` pide datos por teclado y hace `docker exec` para el seed; eso complica ejecutarlo en un pipeline automatizado.
+- `open-wa` necesita Chromium y que alguien escanee el QR para conectar WhatsApp, lo cual no es automático.
+
+## Recomendaciones prácticas
+
+- Centralizar la configuración del demo en un archivo `demo/config.json` que la GUI y el bridge puedan leer; así basta cambiar un sitio para apuntar a otro backend.
+- Hacer el seed idempotente y ofrecerlo como un servicio o comando no interactivo (`npm run seed` o un servicio en `docker-compose`) para poder ejecutarlo en CI.
+- Mantener HTTP como mecanismo por defecto, pero añadir una opción de mensajería (Redis Pub/Sub) para desacoplar componentes si se necesita más robustez.
+
+## Qué migraciones hay
+
+- En `prisma/migrations/` solo aparece una migración principal: `20260520000000_init/migration.sql`.
+- Esa migración crea los enums (`Stage`, `CierreResult`, `ConvStatus`, `ReservationStatus`, `WaitingListStatus`, `AuditActor`, `ChannelType`) y las tablas base (`Lead`, `Conversation`, `Reservation`, `WaitingListEntry`, `StageHistory`, `AuditLog`, `Event`, `TenantConfig`, `TenantCredential`).
+- También define los índices y las claves foráneas entre las tablas relacionadas, por ejemplo `Conversation -> Lead`, `Reservation -> Lead`, `WaitingListEntry -> Lead`, `StageHistory -> Lead`, `AuditLog -> Conversation` y `TenantCredential -> TenantConfig`.
+
+## Archivos de configuración del proyecto
+
+- `.env.example`: documenta las variables esperadas por la app. Ahí se ve el puerto del servidor, `DATABASE_URL`, Redis, clave maestra de cifrado, JWT, métricas y parámetros de rate limiting. También aclara que las credenciales reales del tenant no van en ese archivo.
+- `tsconfig.json`: usa `commonjs`, `target` `ES2021`, `outDir` `./dist`, `baseUrl` `./` y el alias `@/* -> src/*`. Esto explica por qué el código puede importar con rutas cortas.
+- `nest-cli.json`: define `sourceRoot: "src"` y `deleteOutDir: true`, por lo que el compilador de Nest toma `src/` como base y limpia `dist/` en cada build.
+- `package.json`: concentra los scripts importantes (`build`, `start`, `start:dev`, `lint`, `test`, `prisma:*`) y las dependencias clave para el arranque del proyecto: NestJS, Prisma, Redis/Bull, validación, Swagger, OpenTelemetry y el SDK de Anthropic.
+
+## Qué DTO corresponde a qué operación
+
+- `src/dto/conversation.dto.ts`: define `IncomingMessageDto`, que es el contrato que realmente usa la API para recibir mensajes desde la GUI, WhatsApp o Telegram.
+- `src/dto/audit.dto.ts`: define `CreateAuditLogDto`, que corresponde al registro de auditoría de operaciones del sistema.
+- `src/dto/tenant.dto.ts`: define la configuración y las credenciales de tenant que el sistema resuelve en tiempo de ejecución.
+- `src/dto/tool-calls.dto.ts`: agrupa los contratos de herramientas de negocio, como emitir señales de etapa, reservar cupo, liberar cupo, registrar lista de espera y pedir handoff humano.
+
+## Qué importa de `src/` para que `demo/` funcione
+
+- `src/main.ts`: expone la API con el prefijo `api/v1`, CORS y Swagger; la GUI y el bridge dependen de esa base para poder hablar con el orquestador.
+- `src/app.module.ts`: registra la infraestructura general que necesita el demo, sobre todo Config, Throttler, Bull/Redis y los módulos de dominio.
+- `src/channels/webhook.controller.ts`: define las rutas que reciben mensajes de Web, WhatsApp y Telegram. El bridge y la GUI se alinean con ese contrato.
+- `src/common/health.controller.ts`: permite que `demo/start.sh` y la GUI verifiquen si el orquestador está vivo.
+- `src/tenant/tenant-context.middleware.ts`: exige `X-Tenant-Id` o `tenantId` en la ruta, así que el demo debe enviar ese contexto para que la app identifique el tenant.
+- `src/common/rate-limit.guard.ts`: aplica throttling por tenant y no por IP, lo que afecta cómo se comporta la demo cuando se repiten peticiones.
+
+## Cómo encaja la demo con `src/`
+
+- `demo/seed/seed.js` prepara tenant, credenciales y eventos llamando a endpoints de administración del orquestador antes de mandar un mensaje de prueba.
+- `demo/open-wa-bridge/index.js` usa el endpoint de mensajes web del orquestador y el header `X-Tenant-Id` para encaminar los mensajes de WhatsApp.
+- `demo/gui/*` consume el estado y los mensajes que devuelve la API y además consulta `/health` para pintar el estado de los servicios.
+
+Fecha: 2026-06-17

--- a/docs/analisis-codigo/02-infraestructura-orquestacion.md
+++ b/docs/analisis-codigo/02-infraestructura-orquestacion.md
@@ -139,7 +139,7 @@
 
 ## Flujo end-to-end del mensaje
 
-```
+```txt
 Canal (WhatsApp/Telegram/Web)
   └─ WebhookController.parse → IncomingMessageDto
       └─ MessageRouterService.route

--- a/docs/analisis-codigo/02-infraestructura-orquestacion.md
+++ b/docs/analisis-codigo/02-infraestructura-orquestacion.md
@@ -1,0 +1,198 @@
+# 02 - Infraestructura multi-tenant y orquestación del bot
+
+## Resolución de tenant (`src/tenant/`)
+
+- El `TenantConfigService` es la única puerta de entrada para resolver configuración de un tenant. Dado un `tenantId`, consulta primero Redis con la clave `tenant:config:{tenantId}` (TTL 300s). Si no hay caché, lee la tabla `tenantConfig` de la base de datos del sistema, desencripta las credenciales sensibles con `TenantCredentialService` y arma el objeto `TenantConfig` (`llmModel`, `systemPrompt`, `planType`, `maxRequestsMin`, credenciales desencriptadas).
+- Mantiene un `Map<tenantId, PrismaClient>` en memoria con un cliente Prisma por tenant. La primera llamada a `getPrismaClient(tenantId, dbUrl)` crea el cliente y lo guarda; las llamadas siguientes devuelven el mismo cliente, evitando abrir conexiones redundantes. En `onModuleDestroy` cierra todas las conexiones activas.
+- `PrismaSystemService` es el único cliente Prisma que apunta a la base de datos del sistema (donde viven `tenantConfig`, `tenantCredential` y `tenant`). Implementa `OnModuleDestroy` para desconexión ordenada.
+- `TenantCredentialService` cifra y descifra credenciales con AES-256-GCM usando la clave maestra `ENCRYPTION_MASTER_KEY`. Los tipos de credencial soportados son `llm_api_key`, `db_url`, `whatsapp_token` y `telegram_token`. `revokeAll(tenantId)` marca como inactivas todas las credenciales del tenant; `getDecrypted` retorna `null` si la credencial no existe o está inactiva.
+- `TenantContextMiddleware` extrae el `tenantId` de la cabecera `X-Tenant-Id` o, en su defecto, del path param `:tenantId`, y lo adjunta a `req.tenantId`. Si ninguno está presente, lanza `UnauthorizedException`. Está registrado en `ConversationModule` para las rutas `api/v1/:tenantId/*`.
+
+## Pool de conexiones Prisma por tenant
+
+- La estrategia es **database-per-tenant**: cada tenant tiene su propia base de datos y sus credenciales se almacenan cifradas en la base de datos del sistema. El `PrismaClient` por tenant se crea con la URL desencriptada en tiempo de resolución.
+- El `tenantPrismaPool` se inicializa de forma perezosa. No hay eviction policy explícita: las conexiones viven durante todo el ciclo de vida de la aplicación y se cierran en `onModuleDestroy`. Esto es suficiente para un número acotado de tenants, pero requerirá una política de eviction si el número crece.
+- El `tenantId` fluye desde la cabecera HTTP hasta el `PrismaClient` de la siguiente forma: `req.tenantId` (middleware) → `IncomingMessageDto.tenantId` (DTO) → `TenantConfigService.getTenantConfig(tenantId)` → `getPrismaClient(tenantId, dbUrl)`. Ningún servicio accede a la base de datos del tenant sin pasar por el `PrismaClient` resuelto.
+
+## Componentes compartidos (`src/common/`)
+
+- `RateLimitGuard` extiende `ThrottlerGuard` de NestJS. En `getTracker` retorna `tenant:${tenantId}` (tomado de `req.tenantId`, `req.params.tenantId` o `req.headers['x-tenant-id']` en ese orden) en lugar de la IP, de modo que el límite se aplica por tenant y no por origen. Devuelve 429 con cabecera `Retry-After`. La configuración del límite por plan se obtiene desde `TenantConfigService`.
+- `createRedis(prefix?)` es la factory de clientes Redis. Usa ioredis con `lazyConnect: false`, retry con backoff exponencial (máx 3s) y manejadores de error que no crashean el proceso. Acepta un `keyPrefix` opcional que se antepone a todas las claves, útil para namespacing por ambiente.
+- `HealthController` expone `GET /health` (público, sin tenant) y retorna `{ status: 'ok', ts }`. Lo usan Kubernetes y los balanceadores para readiness/liveness.
+
+## Capa de conversación (`src/conversation/`)
+
+### `MessageRouterService`
+
+- Es el único punto de entrada para mensajes de cualquier canal. Su método `route(msg: IncomingMessageDto)` ejecuta la siguiente secuencia: deduplica por `messageId` (Set en memoria), resuelve `TenantConfig` y `PrismaClient` del tenant, busca o crea el `Lead` por `tenantId + channelId + channelType`, busca o crea la `Conversation` activa, registra consentimiento en el primer mensaje y, si la conversación ya está en estado `WITH_OPERATOR` o `HANDOFF_PENDING`, persiste el mensaje en Redis y retorna con `routedTo: 'operator'`.
+- Si la conversación sigue siendo del bot, llama a `AgentRunnerService.run`. Si el runner lanza una excepción, atrapa el error, dispara `HandoffManager.requestHandoff` con `reason: 'fallo_tecnico'` y registra la auditoría del fallo. Esto garantiza que ningún error del agente deja al usuario sin respuesta.
+- Después del run, aplica los eventos de scoring correspondientes a cada transición de etapa, ejecuta la lógica de fallback de `CommercialStageService.processSignal` y, si la etapa final es `SQL`, fuerza un mensaje de escalamiento al humano.
+
+### `AgentRunnerService`
+
+- Ejecuta el ciclo del LLM (CU-COM-002) con un máximo de 10 turnos. En cada turno: carga el historial desde `ConversationSessionStore.getHistory` (Redis, TTL 24h), obtiene la etapa actual desde `CommercialStageService.getStage`, filtra las herramientas disponibles por etapa con `ToolRegistry.getSchemasForStage`, recorta el historial a las últimas 20 entradas para evitar exceder el límite de tokens, y llama a `client.messages.create` del SDK de Anthropic.
+- En `end_turn` extrae la respuesta de texto. Si la respuesta queda vacía tras tool calls, emite un prompt de recuperación para forzar un mensaje legible al usuario.
+- En `tool_use` itera los bloques, despacha cada `tool_use` a `ToolRegistry.get(name).execute(toolContext, input)`, recoge los resultados, los empuja como un mensaje de rol `user` con bloques `tool_result`, refresca etapa y tools, y vuelve a llamar al LLM.
+- Maneja errores específicos: timeout 408 retorna mensaje amigable; errores de crédito o auth 401 activan `escalateToHuman = true`. Al final persiste el historial con `setHistory` y emite un evento `bot_message` al `ConversationEventBusService` para los suscriptores SSE.
+- Emite además eventos `tool_call`, `stage_change`, `escalation` y `error` con payloads estructurados, de modo que el frontend puede renderizar la conversación en tiempo real sin hacer polling.
+
+### `ConversationSessionStore`
+
+- Maneja el historial activo de cada conversación en Redis con la clave `session:{tenantId}:{conversationId}` y TTL de 86400 segundos (24h), alineado con RNF-04.
+- `getHistory` retorna el array de mensajes; si el JSON está corrupto, retorna `[]` en lugar de lanzar excepción. `appendMessage` lee el historial, agrega el nuevo mensaje y reescribe con TTL renovado. `setHistory` reemplaza el array completo. `deleteSession` se usa al cerrar la conversación. `refreshTTL` renueva el TTL sin modificar contenido.
+- Los mensajes del operador se almacenan con `role: 'assistant'` y `sender: 'operator'` para mantener el contrato del LLM intacto al renderizar el historial en prompts futuros.
+
+### `HandoffManagerImpl`
+
+- `requestHandoff(db, tenantId, leadId, conversationId, reason)` genera un `handoffId`, actualiza la conversación a `ConvStatus.HANDOFF_PENDING` y registra el evento `HANDOFF_REQUESTED` en `AuditLog`. Retorna `{ handoffId, queued: true }`.
+- `returnToBot(db, tenantId, conversationId, operatorId)` aplica la guarda A2 de CU-COM-001: si el lead está en etapa `SQL`, rechaza la devolución y retorna `false`. En caso contrario, vuelve la conversación a `ACTIVE`, limpia `assignedTo` y registra `HANDOFF_RETURNED_TO_BOT`.
+
+### `ConversationEventBusService`
+
+- Bus de eventos en memoria basado en `Subject` de RxJS. `getStream(convId)` retorna un `Observable` que se suscribe al subject de la conversación; si no existe, lo crea. `emit(convId, event)` empuja un `MessageEvent` con tipo y datos a todos los suscriptores. Soporta múltiples pestañas de frontend conectadas a la misma conversación.
+- Los tipos de evento soportados son `tool_call`, `stage_change`, `escalation`, `bot_message`, `error` y `api_call`. No hay persistencia: si no hay suscriptores en el momento de emitir, el evento se pierde.
+
+## Tool handlers del agente (`src/tools/`)
+
+- Los 8 tool handlers comparten un `ToolContext` con `tenantId`, `leadId`, `conversationId` y `db` (el `PrismaClient` del tenant resuelto por el router). El `tenantId` nunca viaja en la entrada de la tool: lo provee el orquestador por conversación. Esto cumple el principio de multi-tenant explícito definido en DDR-02.
+- Todas las tools devuelven un `ToolCallResult<T>` con sobre `{ ok: true, data }` en éxito o `{ ok: false, error: { code, message, retryable, details } }` en error. Los códigos válidos son `VALIDATION_ERROR`, `CONSENT_REQUIRED`, `STAGE_PRECONDITION_FAILED`, `NOT_FOUND`, `CONFLICT`, `RATE_LIMITED`, `TEMPORARY_UNAVAILABLE` e `INTERNAL_ERROR`.
+
+### `emit_stage_signal`
+
+- Recibe una señal de transición comercial y persiste los datos de contacto en la tabla `lead` antes de procesarla. Las señales aceptadas son `conversacion_iniciada`, `nombre_capturado`, `correo_capturado`, `numero_capturado`, `pregunta_de_inscripcion_detectada`, `confirmacion_de_pago_pendiente` y `evento_cambiado`. Las señales que dependen de evento (`pregunta_de_inscripcion_detectada`, `evento_cambiado`) requieren `eventId`.
+- Para `nombre_capturado`, `correo_capturado` y `numero_capturado` exige los campos de contacto correspondientes (validación de formato de email con regex). Si la señal es ignorada por la etapa actual, retorna `STAGE_PRECONDITION_FAILED`. La regla B3 hace que cuando `numero_capturado` completa los tres campos, se devuelva un `nextAction` que indica al LLM emitir `pregunta_de_inscripcion_detectada` en el siguiente turno.
+- Depende de `CommercialStageService` y `ScoringService`. Tras procesar la señal, recalcula el score y emite un evento `stage_change` al bus.
+
+### `get_general_context`
+
+- Lee el banco de contexto general del tenant a través de `ContextBankService`. Acepta un parámetro opcional `fields: string[]` para proyectar solo los campos solicitados; si se omite, retorna todo el contexto. Retorna `{ context, updatedAt }` con la fecha de última actualización.
+
+### `get_event_context`
+
+- Lee el banco de contexto de un evento específico. Requiere `eventId` (retorna `VALIDATION_ERROR` si falta) y acepta `fields` opcional. Retorna `{ eventId, context, updatedAt }`. Si el evento no existe, retorna `NOT_FOUND`.
+
+### `reserve_quota`
+
+- Reserva un cupo temporal para un evento. Requiere `eventId` y `idempotencyKey`. La precondición de etapa es `PROSPECTO`: en cualquier otra etapa retorna `STAGE_PRECONDITION_FAILED`. La idempotencia la garantiza `QuotaService` mediante la clave: si ya existe una reserva con esa clave en estado `TEMPORARY`, devuelve la existente. Si la reserva falla por conflicto de cupo, retorna `CONFLICT`. Retorna `{ reservationId, expiresAt }`.
+
+### `release_quota`
+
+- Libera una reserva temporal. Solo requiere `eventId`. No tiene precondición de etapa: se puede liberar desde `PROSPECTO` o `SQL`. Retorna `{ released: boolean }`.
+
+### `block_quota`
+
+- Convierte una reserva temporal en cupo confirmado (post-pago). Requiere `eventId` e `idempotencyKey`. La precondición de etapa es `SQL`: en cualquier otra retorna `STAGE_PRECONDITION_FAILED`. Retorna `{ blocked: boolean }`.
+
+### `register_waiting_list`
+
+- Inscribe al lead en la lista de espera del evento. Requiere `eventId` e `idempotencyKey`. Precondición: etapa `PROSPECTO` y sin cupo disponible. Retorna `{ position }` con la posición ordinal del lead en la lista.
+
+### `request_human_handoff`
+
+- Solicita escalamiento a operador. Requiere `reason` con uno de los valores: `pago_pendiente`, `no_resuelto`, `peticion_del_usuario`, `politica` o `fallo_tecnico`. Despacha a `HandoffManager.requestHandoff` y retorna `{ handoffId, queued: true }`.
+
+### Disponibilidad de herramientas por etapa
+
+| Etapa | Tools disponibles |
+| --- | --- |
+| `LEAD` | `get_general_context`, `emit_stage_signal`, `request_human_handoff` |
+| `MQL` | `get_general_context`, `get_event_context`, `emit_stage_signal`, `reserve_quota`, `register_waiting_list`, `request_human_handoff` |
+| `PROSPECTO` | `get_general_context`, `get_event_context`, `emit_stage_signal`, `reserve_quota`, `release_quota`, `register_waiting_list`, `request_human_handoff` |
+| `SQL` | `get_general_context`, `get_event_context`, `emit_stage_signal`, `block_quota`, `release_quota`, `request_human_handoff` |
+| `CIERRE` | `get_general_context`, `request_human_handoff` |
+
+## Adaptadores de canal (`src/channels/`)
+
+- Los tres adaptadores (`WhatsAppAdapter`, `TelegramAdapter`, `WebAdapter`) **no existen como clases separadas**: la lógica de parsing de cada canal vive directamente en `WebhookController`. La interfaz `IChatChannel` está definida pero no se implementa ni se inyecta en ningún módulo. Esto es deuda técnica pendiente de refactor.
+
+### `WebhookController` — `handleWhatsApp`
+
+- Expone `POST /:tenantId/webhook/whatsapp`. La verificación inicial (GET) responde al challenge de Meta usando `WHATSAPP_VERIFY_TOKEN`. El payload inbound sigue el formato anidado estándar de Meta: `entry[0].changes[0].value.messages[0]`, del que se extraen `from` (teléfono del remitente), `id` (messageId), `text.body` y `timestamp`. Se mapea a `IncomingMessageDto` con `channelType: 'WHATSAPP'` y metadata con `wabaId` y perfil del contacto.
+- El outbound (enviar mensajes) no está implementado: el método solo responde con `{ status: 'ok' }` para confirmar la recepción. Mensajes no textuales retornan `{ status: 'ignored' }` y se descartan.
+
+### `WebhookController` — `handleTelegram`
+
+- Expone `POST /:tenantId/webhook/telegram`. El inbound es un objeto `Update` de la Telegram Bot API; se extraen `message.message_id`, `message.from.id`, `message.text` y `message.date`. Se mapea a `IncomingMessageDto` con `channelType: 'TELEGRAM'` y metadata con `chatId` y `username`.
+- El outbound tampoco está implementado. Mensajes sin texto se ignoran.
+
+### `WebhookController` — `handleWebMessage`
+
+- Expone `POST /:tenantId/messages` para envío de mensajes desde el widget web y `GET /:tenantId/conversations/:convId/events` como stream SSE. El inbound espera `{ channelId, text, messageId? }`; si falta `messageId` se genera como `web-${Date.now()}`. La autenticación se basa en la cabecera `x-session-id` (sin auth real todavía).
+- La respuesta HTTP retorna el `RoutingResult` completo: `conversationId`, `routedTo`, `response`, `stage`, `score`, `toolCallsExecuted`, `leadId` y `handoffTriggered`. El stream SSE se nutre del `ConversationEventBusService` para mostrar tool calls, cambios de etapa y mensajes del bot en tiempo real.
+
+## Operador humano (`src/operator/`)
+
+- Las conversaciones se identifican por estado (`ACTIVE`, `HANDOFF_PENDING`, `WITH_OPERATOR`, `CLOSED`). El endpoint `GET /:tenantId/operator/conversations/all` retorna todas las conversaciones agrupadas por evento, con priorización aplicada. `GET /:tenantId/operator/conversations` filtra solo las escaladas.
+- La agrupación por evento resuelve primero la reserva del lead (TEMPORARY o CONFIRMED), luego la entrada en lista de espera y, como último recurso, hace matching por palabras clave contra el historial Redis y los `etiquetas` del contexto del evento.
+- El algoritmo de ordenamiento (`sortConvs` en `operator.controller.ts`) aplica los siguientes criterios en cascada:
+
+| Prioridad | Criterio | Dirección |
+| --- | --- | --- |
+| 1 | Conversaciones cerradas (CIERRE) | Al final de su grupo |
+| 2 | Estado escalado (`HANDOFF_PENDING`, `WITH_OPERATOR`) | Primero |
+| 3 | Etapa comercial (`LEAD=1` ... `CIERRE=5`) | Mayor primero |
+| 4 | `lead.score` | Mayor primero |
+| 5 | `updatedAt` | Más antiguo primero (FIFO) |
+
+- La asignación se realiza cuando un operador envía el primer mensaje a una conversación en `HANDOFF_PENDING`: el estado pasa a `WITH_OPERATOR` y se graba `assignedTo`. La lista de espera tiene un endpoint separado (`GET /:tenantId/operator/events/:eventId/waitlist`) ordenado por `score DESC` y `joinedAt ASC`.
+- El cierre (`POST /:tenantId/operator/conversations/:convId/close`) acepta `GANADO` o `PERDIDO`. Si es `GANADO`, la reserva temporal se confirma, se incrementan los contadores `confirmedQuota` y la etapa se mueve a `CIERRE` con `cierreResult` registrado.
+
+## Flujo end-to-end del mensaje
+
+```
+Canal (WhatsApp/Telegram/Web)
+  └─ WebhookController.parse → IncomingMessageDto
+      └─ MessageRouterService.route
+          ├─ TenantConfigService.getTenantConfig(tenantId)
+          ├─ TenantConfigService.getPrismaClient(tenantId, dbUrl)
+          ├─ Lead/Conversation: find or create
+          ├─ ConsentService.recordConsent (primer mensaje)
+          ├─ [WITH_OPERATOR|HANDOFF_PENDING]
+          │     └─ SessionStore.appendMessage + audit + return
+          └─ AgentRunnerService.run
+              ├─ SessionStore.getHistory (Redis)
+              ├─ CommercialStageService.getStage
+              ├─ ToolRegistry.getSchemasForStage
+              └─ LLM loop (max 10 turnos)
+                  ├─ [end_turn]    → texto de respuesta
+                  └─ [tool_use]    → ToolRegistry.execute
+                      ├─ emit_stage_signal  → CommercialStage + Scoring
+                      ├─ get_*_context      → ContextBank
+                      ├─ reserve_quota      → QuotaService
+                      ├─ release_quota      → QuotaService
+                      ├─ block_quota        → QuotaService
+                      ├─ register_waiting_list → WaitingListService
+                      └─ request_human_handoff → HandoffManager
+                  └─ SessionStore.setHistory (Redis) + EventBus.emit('bot_message')
+          └─ ScoringService.applyEvent
+          └─ CommercialStageService.processSignal (fallback)
+          └─ [error] HandoffManager.requestHandoff('fallo_tecnico')
+          └─ [SQL]  Mensaje de escalamiento forzado
+          └─ AuditLogService.record('MESSAGE_PROCESSED')
+          └─ return RoutingResult
+```
+
+## Cómo se relacionan estos módulos entre sí
+
+- `MessageRouterService` es el único servicio que recibe mensajes externos; todos los demás servicios son llamados por él o por `AgentRunnerService` a través de tool calls.
+- `TenantConfigService` y `ConversationSessionStore` son transversales: cualquier servicio de dominio puede necesitarlos para resolver un cliente Prisma o leer el historial.
+- `HandoffManager` se inyecta en `MessageRouterService` (para errores técnicos) y en el tool handler `request_human_handoff` (para escalamientos solicitados). La interfaz es la misma en ambos casos.
+- `ConversationEventBusService` solo lo consume `AgentRunnerService` (productor) y el `WebhookController` (consumidor SSE).
+- El `ToolRegistry` es el punto único de despacho de tool calls: oculta la lista de handlers al LLM y aplica la política de qué tools están disponibles por etapa.
+
+## Trazabilidad con casos de uso
+
+| Clase / Servicio | CU | Responsabilidad |
+| --- | --- | --- |
+| `MessageRouterService` | CU-COM-001 | Recibe webhook, crea conversación, resuelve tenant, asigna bot u operador |
+| `AgentRunnerService` | CU-COM-002 | Ejecuta el ciclo LLM: mensaje → tool calls → respuesta |
+| `ConversationSessionStore` | CU-COM-002 | Historial activo en Redis con TTL 24h |
+| `HandoffManagerImpl` | CU-COM-001 | Gestiona transición bot↔operador y colas de atención humana |
+| `TenantConfigService` | CU-COM-001 | Resuelve configuración y credenciales por tenant |
+| `CommercialStageService` | CU-COM-005 | Máquina de estados de etapa comercial |
+| `ScoringService` | CU-COM-005 | Recalcula score 0-20, detecta exploits |
+| `ContextBankService` | CU-COM-003 | Lectura/escritura de bancos de contexto (general y evento) |
+| `QuotaService` | CU-EVT-003 | Reserva, liberación y bloqueo de cupos |
+| `WaitingListService` | CU-EVT-001 | Registro y ordenamiento de lista de espera (score DESC, FIFO) |
+| `ConsentService` | CU-COM-004 | Avisos legales y registro de consentimiento tácito |
+| `AuditLogService` | CU-COM-001 | Log append-only con `conversationId` y `transactionId` |

--- a/docs/analisis-codigo/03-servicios-dominio-notificaciones.md
+++ b/docs/analisis-codigo/03-servicios-dominio-notificaciones.md
@@ -64,7 +64,7 @@
 - El `MetricsService` (`src/observability/metrics.service.ts`) expone métricas Prometheus en un `Registry` propio. Las métricas definidas son:
 
 | Nombre | Tipo | Qué mide |
-|---|---|---|
+| --- | --- | --- |
 | `bot_conversations_started_total` | Counter | Conversaciones iniciadas por tenant |
 | `bot_conversations_transferred_total` | Counter | Transfers a operador (con razón) |
 | `bot_conversations_closed_total` | Counter | Conversaciones cerradas |

--- a/docs/analisis-codigo/03-servicios-dominio-notificaciones.md
+++ b/docs/analisis-codigo/03-servicios-dominio-notificaciones.md
@@ -1,0 +1,103 @@
+# 03 - Servicios de dominio, notificaciones y observabilidad
+
+## Máquina de estados comercial (`src/commercial/commercial-stage.service.ts`)
+
+- El `CommercialStageService` implementa la progresión de un lead a través de cinco etapas: `LEAD → MQL → PROSPECTO → SQL → CIERRE`. La tabla de transiciones válidas está definida estáticamente en `TRANSITIONS` y es la única fuente de verdad sobre qué señales avanzan qué etapas.
+- Cuando el bot emite una señal (por ejemplo `nombre_capturado` o `pregunta_de_inscripcion_detectada`), el servicio busca si existe una transición válida desde la etapa actual. Si no existe, devuelve `changed: false` y registra un aviso en el logger sin lanzar excepción, lo que permite que el flujo conversacional continúe.
+- Cada transición válida se ejecuta dentro de una transacción Prisma que actualiza `Lead.currentStage` y crea un registro en `StageHistory` con el `transactionId` correspondiente. Si el destino es `SQL`, también actualiza la conversación a `HANDOFF_PENDING` para que el operador tome el caso.
+- La única señal que permite retroceso es `evento_cambiado`: desde `SQL` regresa a `PROSPECTO`, lo que cubre el caso en que el lead cambia de evento antes del cierre.
+- Toda transición queda auditada en `AuditLog` con `actor: SYSTEM` y `action: STAGE_TRANSITION`.
+
+## Calificación continua (`src/commercial/scoring.service.ts`)
+
+- El `ScoringService` mantiene un puntaje 0–20 por lead. Los eventos que modifican el score están definidos en el mapa `SCORE_RULES`: acciones positivas como `contact_data_provided` (+3) o `payment_confirmed` (+5) y acciones negativas como `spam_detected` (-4) o `exploit_attempt` (-5).
+- La calificación es independiente de la etapa: el puntaje no provoca transiciones ni avances de etapa; solo influye en la priorización de la lista de espera.
+- Los intentos de manipulación (`exploit_attempt`) se acumulan en un `Map` en memoria por `tenantId:leadId`. Al segundo intento se activa la bandera `exploitReincidente`, que el consumidor puede usar para bloquear la conversación.
+- Cada actualización de score queda auditada con `action: SCORE_UPDATE` e incluye el delta, el score anterior y si se detectó exploit reincidente.
+
+## Contexto del tenant y del evento (`src/context-bank/context-bank.service.ts`)
+
+- El `ContextBankService` es el único punto de acceso de lectura y escritura de contexto (CU-COM-003). Ningún otro servicio lee directamente `TenantConfig.contextData` ni `Event.contextData`.
+- Para el contexto general del tenant lee de Redis primero (clave `ctx:general:{tenantId}`, TTL de 5 minutos) y, si no hay caché, consulta `TenantConfig` en la base de datos del tenant. Lo mismo aplica para el contexto de evento con clave `ctx:event:{tenantId}:{eventId}`.
+- Expone métodos de invalidación explícita (`invalidateEventContext`, `invalidateGeneralContext`) que se deben llamar cuando se actualizan los datos del evento o del tenant para forzar la recarga desde la base de datos en la siguiente consulta.
+
+## Gestión de cupos (`src/events/quota.service.ts`)
+
+- El `QuotaService` maneja tres operaciones sobre cupos: reserva temporal, liberación y bloqueo definitivo (CU-EVT-003).
+- La reserva (`reserveQuota`) usa `SELECT ... FOR UPDATE` vía `$queryRaw` para leer `totalQuota`, `reservedQuota` y `confirmedQuota` de forma atómica. Si `totalQuota - reservedQuota - confirmedQuota <= 0` lanza `ConflictException`. De lo contrario, incrementa `reservedQuota` y crea una `Reservation` con estado `TEMPORARY` dentro de la misma transacción Prisma.
+- Inmediatamente después de la reserva, encola un job `expire` en la cola BullMQ `reservation-expiry` con un delay de 30 minutos, 3 reintentos y backoff exponencial.
+- La idempotencia se garantiza mediante `idempotencyKey`: si ya existe una reserva con esa clave en estado `TEMPORARY`, se devuelve la reserva existente sin tocar la base de datos.
+- El bloqueo definitivo (`blockQuota`) convierte una reserva `TEMPORARY` en `CONFIRMED`, decrementa `reservedQuota` e incrementa `confirmedQuota` en la misma transacción, evitando cualquier ventana donde el cupo quede descontado dos veces.
+- La liberación por expiración (`expireReservation`) es llamada por el `ReservationExpiryProcessor` y solo actúa si la reserva sigue en estado `TEMPORARY`; si ya fue confirmada o liberada, no hace nada.
+
+## Lista de espera (`src/events/waiting-list.service.ts`)
+
+- El `WaitingListService` gestiona el orden de espera para un evento cuando no hay cupo disponible (CU-EVT-001). Solo los leads en etapa `PROSPECTO` pueden unirse.
+- El orden combina score descendente y fecha de ingreso ascendente (FIFO como desempate). En Redis se almacena como un `Sorted Set` donde el score del conjunto es `lead.score * 1e10 - joinedAt.getTime()`, lo que garantiza el orden correcto con una sola clave numérica.
+- La posición de un lead se consulta vía `ZREVRANK` en Redis (O(log N)) y cae de regreso a la base de datos si el lead no está en el conjunto.
+- Antes de notificar a los candidatos (`getNextEligible`), el servicio verifica en la base de datos que cada lead siga siendo `PROSPECTO` y que su entrada esté en estado `WAITING`, descartando a quienes hayan cambiado de estado desde que se unieron.
+
+## Cancelación de inscripciones (`src/events/cancellation.service.ts`)
+
+- El `CancellationService` cubre el caso en que un operador anula una inscripción antes de que inicie el evento (CU-EVT-002).
+- Busca la reserva activa del lead en el evento (estado `TEMPORARY` o `CONFIRMED`) y dentro de una transacción la marca como `RELEASED` y decrementa el contador correcto: `reservedQuota` si era temporal o `confirmedQuota` si ya estaba confirmada.
+- Registra en auditoría con `actor: OPERATOR` y `action: INSCRIPTION_CANCELLED`, incluyendo el `operatorId` y el estado previo de la reserva.
+- No dispara notificaciones directamente: la liberación del cupo es responsabilidad del flujo que llama a este servicio (el operador o el job de expiración).
+
+## Notificaciones y jobs asíncronos (`src/notifications/`)
+
+- El `NotificationService` coordina el envío de notificaciones a la lista de espera cuando se liberan vacantes. Al recibir `notifyWaitlistBatch(vacanciesFreed)`, consulta los siguientes elegibles y, por cada uno, marca su entrada como `NOTIFIED` en la base de datos, establece un `expiresAt` de 2 horas para aceptar y encola un job en la cola BullMQ `notification` con 3 reintentos y delay fijo de 10 minutos entre reintentos.
+- El `ReservationExpiryProcessor` (`src/notifications/reservation-expiry.processor.ts`) escucha la cola `reservation-expiry`. Al procesar un job, llama a `QuotaService.expireReservation` para marcar la reserva como expirada y liberar el cupo, luego consulta el siguiente elegible en la lista de espera y le envía notificación.
+- El `OutboundNotificationProcessor` (`src/notifications/outbound-notification.processor.ts`) escucha la cola `outbound-notification` y aplica dos filtros antes de enviar: verifica que el lead tenga `consentAt` registrado (CU-COM-004) y que no haya recibido una notificación outbound en los últimos 7 días consultando `AuditLog`. Si ambas condiciones se cumplen, registra `action: OUTBOUND_NOTIFICATION_SENT` en auditoría.
+
+## Auditoría (`src/audit/audit-log.service.ts`)
+
+- El `AuditLogService` es el registro append-only transversal del sistema. Todos los servicios de dominio lo usan para documentar cada operación relevante.
+- Los campos de cada entrada son: `tenantId`, `conversationId`, `transactionId`, `actor` (`SYSTEM` u `OPERATOR`), `action` (string que identifica el tipo de evento) y `payload` (JSON con detalles específicos de la acción).
+- El método `record` captura cualquier error de escritura sin relanzarlo, de modo que un fallo en auditoría no bloquea el flujo principal. El error se emite al logger para diagnóstico.
+- El método `recordBatch` permite auditar múltiples eventos en una sola operación `createMany`, útil para procesos masivos.
+- Las acciones que escriben en auditoría son: `STAGE_TRANSITION`, `SCORE_UPDATE`, `QUOTA_RESERVED`, `QUOTA_RELEASED`, `QUOTA_BLOCKED`, `WAITLIST_REGISTERED`, `WAITLIST_NOTIFICATION_SENT`, `INSCRIPTION_CANCELLED`, `OUTBOUND_NOTIFICATION_SENT`.
+
+## Observabilidad (`src/observability/`)
+
+- `src/observability/tracing.ts` inicializa el SDK de OpenTelemetry y debe importarse antes de cualquier otro módulo (está registrado en `main.ts`). Configura un `SimpleSpanProcessor` que exporta trazas en formato OTLP-HTTP al endpoint definido en `OTEL_EXPORTER_OTLP_ENDPOINT` (por defecto `http://localhost:4318`). La instrumentación incluye `HttpInstrumentation` para rastrear peticiones HTTP automáticamente.
+- El `MetricsService` (`src/observability/metrics.service.ts`) expone métricas Prometheus en un `Registry` propio. Las métricas definidas son:
+
+| Nombre | Tipo | Qué mide |
+|---|---|---|
+| `bot_conversations_started_total` | Counter | Conversaciones iniciadas por tenant |
+| `bot_conversations_transferred_total` | Counter | Transfers a operador (con razón) |
+| `bot_conversations_closed_total` | Counter | Conversaciones cerradas |
+| `bot_exploit_detected_total` | Counter | Intentos de manipulación detectados |
+| `quota_reservations_expired_total` | Counter | Reservas expiradas por tenant y evento |
+| `bot_token_cost_total` | Counter | Tokens acumulados por tenant y modelo |
+| `bot_conversations_active` | Gauge | Conversaciones activas concurrentes |
+| `bot_message_latency_ms` | Histogram | Latencia end-to-end de mensaje |
+| `bot_tool_call_latency_ms` | Histogram | Latencia por tool call |
+| `bot_llm_latency_ms` | Histogram | Latencia de llamada al LLM |
+
+- El `MetricsController` expone el endpoint `GET /metrics` en el formato que Prometheus espera para scraping.
+
+## Cómo se relacionan estos módulos entre sí
+
+- `CommercialStageService` y `ScoringService` reciben la instancia `PrismaClient` del tenant como parámetro en cada llamada; no tienen acceso directo a la base de datos ni la crean ellos mismos.
+- `QuotaService` depende de `AuditLogService` y de la cola BullMQ `reservation-expiry`. El job que encola es procesado por `ReservationExpiryProcessor`, que a su vez invoca `QuotaService` y `NotificationService`, creando un ciclo asíncrono controlado por BullMQ.
+- `WaitingListService` depende de `AuditLogService` y de Redis directamente (a través de `createRedis`). Es consumido por `NotificationService` para obtener los siguientes elegibles.
+- `AuditLogService` no tiene dependencias de dominio; es el único servicio que todos los demás inyectan.
+- `ContextBankService` es independiente de los demás servicios de dominio; solo depende de Redis y de la instancia `PrismaClient` del tenant.
+
+## Riesgos y cosas a tener en cuenta
+
+- El contador de exploits en `ScoringService` (`exploitCount: Map`) vive en memoria del proceso. Si la aplicación se reinicia o escala horizontalmente con múltiples instancias, el contador se pierde o se desincroniza entre instancias. Un lead reincidente podría no ser detectado si sus mensajes caen en distintos pods.
+- El `SimpleSpanProcessor` en `tracing.ts` exporta spans de forma síncrona en cada operación. En producción con volumen alto se recomienda cambiar a `BatchSpanProcessor` para no bloquear el hilo principal con cada exportación.
+- La auditoría silencia sus errores para no interrumpir el flujo. Esto es correcto para disponibilidad, pero significa que puede haber huecos en el registro sin que nadie se entere. Sería conveniente emitir una métrica o alerta cuando falle `record`.
+- La lista de espera en Redis puede desincronizarse con la base de datos si un proceso falla entre el `upsert` en DB y el `zadd` en Redis. No hay mecanismo de reconciliación automática; sería necesario un job periódico que recomponga el Sorted Set desde la tabla `WaitingListEntry`.
+
+## Recomendaciones prácticas
+
+- Mover el contador de exploits reincidentes de la memoria del servicio a un `Sorted Set` o `Hash` en Redis con TTL, para que sea consistente en despliegues multi-instancia.
+- Reemplazar `SimpleSpanProcessor` por `BatchSpanProcessor` en el inicializador de OpenTelemetry antes de llevar la aplicación a carga real.
+- Agregar un job de reconciliación periódico que compare `WaitingListEntry` (DB) con el `Sorted Set` de Redis y corrija diferencias.
+- Registrar una métrica de fallo de auditoría (`audit_record_failed_total`) para visibilizar en el dashboard de Prometheus cuando el registro append-only pierde entradas.
+
+Fecha: 2026-06-22

--- a/docs/analisis-codigo/Max.md
+++ b/docs/analisis-codigo/Max.md
@@ -1,0 +1,20 @@
+# Análisis del acoplamiento entre módulos    y propuestas de diseño
+
+## Qué encontré
+
+- Hay un orquestador, una interfaz web estática, un puente para WhatsApp y scripts que preparan datos de ejemplo. Todos dependen unos de otros para funcionar correctamente.
+- Muchas decisiones están orientadas a facilitar la ejecución local (uso de direcciones relativas), lo cual es útil para demos pero deben ser cambiadas para el producto final.
+
+## Problemas principales
+
+- Dependencias: algunos componentes esperan valores concretos (por ejemplo, direcciones y nombres) que están repartidos en distintos lugares, por lo que un cambio pequeño obliga a tocar varios archivos.
+- Dificultad para ejecutar por partes: no es sencillo arrancar solo la interfaz o solo el puente sin el resto, porque el flujo asume que todo está presente y activo.
+- Fragilidad frente a cambios: la interfaz interpreta registros y respuestas en formatos poco estructurados, así que cualquier cambio en el servidor puede romper la experiencia de usuario.
+
+## Propuestas
+
+- Unificar la configuración en un solo lugar y que las partes la lean en tiempo de ejecución, en lugar de repetir valores en muchos archivos. Así será más fácil cambiar dónde corre cada cosa.
+- Separar la preparación de datos (seed) del resto: que exista una forma clara y repetible de cargar datos de muestra sin tener que ejecutar comandos manuales dentro de contenedores.
+- Desacoplar cómo se comunican los componentes: en vez de depender fuertemente de una llamada directa entre dos piezas, introducir una forma de intercambio más flexible que permita que cada parte funcione de manera independiente cuando sea necesario.
+- Acordar formatos claros y estables para la información que intercambian la interfaz y el servidor, para evitar que cambios menores rompan el comportamiento.
+- Reducir o eliminar pasos interactivos para posibilitar ejecuciones automáticas en entornos de prueba y en integraciones continuas.

--- a/docs/analisis-codigo/Propuestas_Max.md
+++ b/docs/analisis-codigo/Propuestas_Max.md
@@ -1,0 +1,156 @@
+# Propuestas de diseño detalladas
+
+## Detalle: Unificar la configuración
+
+Por "unificar la configuración" me refiero a dejar los valores que pueden cambiar según el entorno (direcciones de servicios, puertos, identificadores de tenant, flags de comportamiento) en un único lugar que todas las partes del demo consulten en tiempo de ejecución. Actualmente esos valores están repartidos entre varios archivos y scripts; si cambias uno, a veces hay que actualizar varios sitios.
+
+Beneficios principales:
+
+- Menos errores por valores desincronizados.
+- Posibilidad de ejecutar solo una parte del sistema (por ejemplo, la interfaz) apuntando a otro backend sin tener que reconstruir nada.
+- Facilita la automatización y las pruebas, porque los entornos se configuran cambiando un único archivo o variable.
+
+Propuesta de pasos prácticos (incremental y reversible):
+
+1. Definir un archivo de configuración simple en la raíz de `demo/` que sea JSON y contenga las claves que hoy están dispersas (por ejemplo: URL base del orquestador, puerto del bridge, tenant). Este archivo se sirve o se monta en los procesos que lo necesiten.
+2. Cambiar la interfaz y el bridge para que lean esa configuración al inicio en lugar de usar valores codificados. Al principio esto puede fallar si no existe el archivo; documentar el formato y mantener los valores por defecto para compatibilidad.
+3. Actualizar `start.sh` y `docker-compose.yml` para montar o servir dicho archivo cuando se levante el demo.
+
+Ejemplo breve (solo formato; conservar en `Max2.md` para implementación):
+
+```json
+{
+    "API_BASE": "http://localhost:3000/api/v1",
+    "TENANT_ID": "demo-tenant",
+    "BRIDGE_URL": "http://localhost:4000"
+}
+```
+
+Notas de seguridad y operación:
+
+- No incluir credenciales sensibles en el archivo JSON si va a ser servido públicamente; usar variables de entorno o un mecanismo de secretos para llaves privadas.
+- Mantener valores por defecto en el código durante una transición corta para evitar romper demos existentes.
+
+## Detalle: Separar la preparación de datos (seed)
+
+Problema observado:
+
+- Actualmente la carga de datos de ejemplo se realiza de forma manual (por ejemplo, `docker exec` a un contenedor) o con scripts acoplados al entorno, lo que dificulta la reproducibilidad y la automatización.
+
+Beneficios de separarlo:
+
+- Permite reproducir entornos idénticos en CI/CD y en nuevos desarrollos.
+- Evita la necesidad de intervenir contenedores en ejecución para inicializar datos.
+- Facilita pruebas e integración continua si la preparación es idempotente y declarativa.
+
+Propuesta de pasos prácticos:
+
+1. Crear un servicio `seed` opcional en `docker-compose.yml` que ejecute `node seed/seed.js` (o el script correspondiente) una única vez. Configurar `restart: "no"` para que no vuelva a ejecutar.
+2. Alternativamente, ofrecer un script CLI en `demo/` (`npm run seed` o `node seed/seed.js`) que pueda ejecutarse desde pipelines y entornos locales.
+3. Hacer que el script de seed sea idempotente: comprobar si los datos ya existen y en ese caso no volver a insertarlos.
+4. Documentar el procedimiento en `README.md` del demo y eliminar la recomendación de usar `docker exec` en la ruta normal de puesta en marcha.
+
+Ejemplo de fragmento para `docker-compose.yml` (formato ilustrativo):
+
+```yaml
+    seed:
+        image: node:18
+        working_dir: /app
+        volumes:
+            - ./seed:/app/seed:ro
+        command: ["node", "seed/seed.js"]
+        depends_on:
+            - orchestrator
+        restart: "no"
+```
+
+## Detalle: Desacoplar la comunicación entre componentes
+
+Problema observado:
+
+- El `open-wa-bridge` y el orquestador están acoplados mediante llamadas HTTP directas y URLs codificadas, lo que obliga a que ambos estén simultáneamente disponibles y complica escalado o pruebas aisladas.
+
+Beneficios de desacoplar:
+
+- Componentes independientes pueden funcionar, escalar y desplegarse separadamente.
+- Mejora la resiliencia: pérdida temporal de un componente no bloquea al resto.
+- Facilita integrar reemplazos (por ejemplo, otra pasarela de mensajería) sin cambiar el orquestador.
+
+Propuesta de pasos prácticos:
+
+1. Introducir un mecanismo opcional de mensajería (Redis Pub/Sub, RabbitMQ o una cola ligera) como capa de desacoplamiento. Mantener la llamada HTTP directa como fallback durante la transición.
+2. Modificar `open-wa-bridge` para publicar eventos (por ejemplo `message.received`) en el bus y suscribirse a canales de control si es necesario.
+3. Hacer que el orquestador consuma eventos desde el bus en lugar de depender exclusivamente de endpoints HTTP expuestos por el bridge.
+4. Documentar el contrato de eventos (nombres de tópico/evento y formato JSON) y ofrecer ejemplos.
+
+Ejemplo de mensaje (formato sugerido):
+
+```json
+{
+    "event": "message.received",
+    "tenant": "demo-tenant",
+    "payload": {
+        "from": "+5491122334455",
+        "text": "Hola",
+        "id": "msg-123"
+    },
+    "timestamp": "2026-06-17T12:00:00Z"
+}
+```
+
+Notas operativas:
+
+- Mantener la solución opcional: forzar a usar pub/sub solo cuando se quiera escalar o testear en aislamiento.
+- Añadir healthchecks para la cola y métricas para latencia de entrega.
+
+## Detalle: Acordar formatos claros y estables (OpenAPI / JSON Schema)
+
+Problema observado:
+
+- La interfaz y el servidor intercambian datos en formatos poco formalizados; la interfaz incluso analiza texto de logs en vez de consumir datos estructurados.
+
+Beneficios de formalizar contratos:
+
+- Reduce roturas por cambios inesperados en la API o en eventos.
+- Permite generar clientes, mocks y validaciones automáticas.
+- Facilita pruebas de contrato entre front-end y back-end.
+
+Propuesta de pasos prácticos:
+
+1. Definir un `openapi.yaml` mínimo para los endpoints públicos que utiliza la GUI (health, fetch events, post messages, etc.).
+2. Definir JSON Schema para los eventos y mensajes que circulan entre bridge y orquestador.
+3. Añadir validación ligera en el orquestador (por ejemplo, usando Ajv en Node.js) para rechazar payloads inválidos con errores claros.
+4. Integrar Swagger UI o Redoc en modo documentación para que desarrolladores y QA tengan referencias vivas.
+
+Ejemplo de fragmento de schema (ilustrativo):
+
+```json
+{
+    "$id": "https://example.org/schemas/message.json",
+    "type": "object",
+    "required": ["from", "text", "id"],
+    "properties": {
+        "from": { "type": "string" },
+        "text": { "type": "string" },
+        "id": { "type": "string" }
+    }
+}
+```
+
+## Detalle: Reducir o eliminar pasos interactivos
+
+Problema observado:
+
+- Algunos scripts de arranque o tareas del demo requieren interacción manual, lo que impide automatizar despliegues y pruebas.
+
+Beneficios de automatizar:
+
+- Permite integrar el demo en pipelines de CI/CD y ejecutar pruebas reproducibles.
+- Mejora la experiencia de desarrolladores nuevos que deben seguir pasos claros y no interactivos.
+
+Propuesta de pasos prácticos:
+
+1. Hacer que `start.sh` acepte banderas y variables de entorno para ejecutarse sin preguntas (por ejemplo `START_INTERACTIVE=false`).
+2. Ofrecer comandos `npm` o `Makefile` que encapsulen pasos comunes sin interacción.
+3. Documentar los modos: `dev` (rápido, con valores por defecto), `ci` (no interactivo, usa `seed` idempotente y healthchecks) y `prod` (más restricciones de seguridad).
+4. Mantener mensajes informativos en logs en lugar de prompts que requieren respuesta.

--- a/docs/analisis-codigo/resumen-general.md
+++ b/docs/analisis-codigo/resumen-general.md
@@ -1,0 +1,113 @@
+# Resumen general — Análisis de código (rama `claude-develop`)
+
+## Propósito
+
+Este documento sintetiza el análisis de código de la rama `claude-develop`, dividido en tres sub-issues (PSD-42, PSD-43, PSD-44) que cubren en conjunto los directorios `src/` y `prisma/`. No repite el detalle de cada módulo — para eso están los documentos `01`, `02` y `03` — sino que describe cómo se compone la arquitectura general, cómo se relacionan las capas entre sí y dónde el código real coincide o se desvía del blueprint documentado en [`ARCH-ESTRUCTURA-CODIGO`](../diseño/arquitectura/estructura-de-codigo.md).
+
+El alcance, los criterios de aceptación y la división del trabajo están definidos en el issue padre PSD-41 (#108) y sus tres sub-issues PSD-42 (#109), PSD-43 (#110) y PSD-44 (#111).
+
+## Documentos fuente
+
+| Documento | Cubre | Sub-issue |
+| --- | --- | --- |
+| [01-configuracion-prisma-demo.md](01-configuracion-prisma-demo.md) | Arranque de NestJS (`main.ts`, `app.module.ts`), schema de Prisma, migraciones, DTOs y la carpeta `demo/` | PSD-42 (#109) |
+| [02-infraestructura-orquestacion.md](02-infraestructura-orquestacion.md) | Multi-tenant (`src/tenant/`), capa de conversación, los 8 tool handlers, adaptadores de canal y operador humano | PSD-43 (#110) |
+| [03-servicios-dominio-notificaciones.md](03-servicios-dominio-notificaciones.md) | Etapa comercial, scoring, banco de contexto, cupos, lista de espera, cancelación, notificaciones, auditoría y observabilidad | PSD-44 (#111) |
+
+## Arquitectura general
+
+El sistema es un orquestador SaaS multi-tenant construido en NestJS sobre el principio rector de `DDR-02`:
+
+```txt
+El bot emite señales. El sistema ejecuta operaciones de dominio.
+```
+
+En la práctica esto se traduce en tres capas que se llaman en cascada y que corresponden 1 a 1 con los tres sub-documentos:
+
+```txt
+Capa 1 — Base (doc 01)
+  main.ts / app.module.ts / prisma/schema.prisma / demo/
+        │
+        ▼
+Capa 2 — Infraestructura y orquestación (doc 02)
+  tenant/ → conversation/ (MessageRouter, AgentRunner) → tools/ → channels/ → operator/
+        │
+        ▼
+Capa 3 — Servicios de dominio, notificaciones y observabilidad (doc 03)
+  commercial/ · context-bank/ · events/ · notifications/ · audit/ · observability/
+```
+
+- **Capa 1 (base):** `src/main.ts` levanta la aplicación (Swagger, CORS, validación global) y `src/app.module.ts` registra todos los módulos de dominio más la integración con Redis/Bull. `prisma/schema.prisma` define el contrato de persistencia (`Lead`, `Conversation`, `Reservation`, `WaitingListEntry`, `Event`, `StageHistory`, `AuditLog`, `TenantConfig`, `TenantCredential`) que las capas 2 y 3 consumen. `demo/` es el único consumidor externo que ejercita el sistema de punta a punta sin pasar por un canal real.
+- **Capa 2 (infraestructura y orquestación):** resuelve **quién** habla (tenant, canal, lead) y **cómo** se procesa el turno conversacional. `MessageRouterService` es la única puerta de entrada de mensajes; delega en `AgentRunnerService`, que ejecuta el ciclo del LLM y despacha tool calls a través del `ToolRegistry`.
+- **Capa 3 (dominio):** resuelve **qué pasa con el lead y el evento** cuando una tool call se ejecuta — transición de etapa, score, cupos, lista de espera, notificaciones — y deja constancia en auditoría y observabilidad.
+
+Ninguna capa accede a la capa anterior en sentido inverso: los servicios de dominio (capa 3) no conocen detalles de canal ni de transporte (capa 2), y la capa 2 no conoce el formato de persistencia más allá del `PrismaClient` que la capa 1 expone por tenant.
+
+## Relación entre módulos (vista consolidada)
+
+| Módulo / Servicio | Ruta principal | Capa | CU | Detalle |
+| --- | --- | --- | --- | --- |
+| Bootstrap NestJS | `src/main.ts`, `src/app.module.ts` | 1 | — | [01](01-configuracion-prisma-demo.md#cómo-arranca-la-aplicación) |
+| Schema Prisma | `prisma/schema.prisma`, `prisma/migrations/` | 1 | — | [01](01-configuracion-prisma-demo.md#qué-migraciones-hay) |
+| Demo | `demo/seed/`, `demo/open-wa-bridge/`, `demo/gui/` | 1 | — | [01](01-configuracion-prisma-demo.md#qué-hace-la-carpeta-demo-flujos-principales) |
+| `TenantConfigService` | `src/tenant/` | 2 | CU-COM-001 | [02](02-infraestructura-orquestacion.md#resolución-de-tenant-srctenant) |
+| `MessageRouterService` | `src/conversation/` | 2 | CU-COM-001 | [02](02-infraestructura-orquestacion.md#messagerouterservice) |
+| `AgentRunnerService` | `src/conversation/` | 2 | CU-COM-002 | [02](02-infraestructura-orquestacion.md#agentrunnerservice) |
+| `ConversationSessionStore` | `src/conversation/` | 2 | CU-COM-002 | [02](02-infraestructura-orquestacion.md#conversationsessionstore) |
+| `HandoffManagerImpl` | `src/conversation/` | 2 | CU-COM-001 | [02](02-infraestructura-orquestacion.md#handoffmanagerimpl) |
+| 8 tool handlers | `src/tools/` | 2 | CU-COM-003/005, CU-EVT-001/003 | [02](02-infraestructura-orquestacion.md#tool-handlers-del-agente-srctools) |
+| `WebhookController` (canales) | `src/channels/` | 2 | CU-COM-001 | [02](02-infraestructura-orquestacion.md#adaptadores-de-canal-srcchannels) |
+| Operador humano | `src/operator/` | 2 | CU-COM-001 | [02](02-infraestructura-orquestacion.md#operador-humano-srcoperator) |
+| `CommercialStageService` | `src/commercial/` | 3 | CU-COM-005 | [03](03-servicios-dominio-notificaciones.md#máquina-de-estados-comercial-srccommercialcommercial-stageservicets) |
+| `ScoringService` | `src/commercial/` | 3 | CU-COM-005 | [03](03-servicios-dominio-notificaciones.md#calificación-continua-srccommercialscoringservicets) |
+| `ContextBankService` | `src/context-bank/` | 3 | CU-COM-003 | [03](03-servicios-dominio-notificaciones.md#contexto-del-tenant-y-del-evento-srccontext-bankcontext-bankservicets) |
+| `QuotaService` | `src/events/` | 3 | CU-EVT-003 | [03](03-servicios-dominio-notificaciones.md#gestión-de-cupos-srceventsquotaservicets) |
+| `WaitingListService` | `src/events/` | 3 | CU-EVT-001 | [03](03-servicios-dominio-notificaciones.md#lista-de-espera-srceventswaiting-listservicets) |
+| `CancellationService` | `src/events/` | 3 | CU-EVT-002 | [03](03-servicios-dominio-notificaciones.md#cancelación-de-inscripciones-srceventscancellationservicets) |
+| `NotificationService` + jobs BullMQ | `src/notifications/` | 3 | CU-COM-006 | [03](03-servicios-dominio-notificaciones.md#notificaciones-y-jobs-asíncronos-srcnotifications) |
+| `AuditLogService` | `src/audit/` | 3 | CU-COM-001 | [03](03-servicios-dominio-notificaciones.md#auditoría-srcauditaudit-logservicets) |
+| Observabilidad (OTel + Prometheus) | `src/observability/` | 3 | — | [03](03-servicios-dominio-notificaciones.md#observabilidad-srcobservability) |
+
+## Flujo end-to-end (capas 2 y 3 combinadas)
+
+El recorrido completo de un mensaje, documentado en detalle en [02](02-infraestructura-orquestacion.md#flujo-end-to-end-del-mensaje) y [03](03-servicios-dominio-notificaciones.md#cómo-se-relacionan-estos-módulos-entre-sí), es:
+
+1. Un canal (`WhatsApp`/`Telegram`/`Web`) entra por `WebhookController` y se normaliza a `IncomingMessageDto`.
+2. `MessageRouterService` resuelve tenant y `PrismaClient` (capa 1→2), encuentra o crea `Lead`/`Conversation`, y decide si el turno lo atiende el bot o un operador humano.
+3. Si lo atiende el bot, `AgentRunnerService` ejecuta el ciclo LLM y despacha tool calls (`src/tools/`) que llaman a los servicios de dominio de la capa 3: `CommercialStageService`, `ScoringService`, `ContextBankService`, `QuotaService`, `WaitingListService`, `HandoffManager`.
+4. Cada operación de dominio relevante queda en `AuditLogService` (capa 3) y, si afecta cupos, puede encolar jobs BullMQ (`reservation-expiry`, `notification`) que retroalimentan a `NotificationService`.
+5. La observabilidad (OpenTelemetry + Prometheus) instrumenta este recorrido de forma transversal, sin que ningún servicio de dominio dependa de ella directamente.
+
+## Contraste con el blueprint arquitectónico (`ARCH-ESTRUCTURA-CODIGO`)
+
+El blueprint en [`docs/diseño/arquitectura/estructura-de-codigo.md`](../diseño/arquitectura/estructura-de-codigo.md) (estado "Propuesto") definió la estructura objetivo antes de implementar. El análisis de `claude-develop` confirma que las capas y bounded contexts se respetaron, con estas diferencias puntuales detectadas en los sub-documentos:
+
+| Punto del blueprint | Estado en `claude-develop` | Fuente |
+| --- | --- | --- |
+| Carpeta `src/tool-calls/` con DTOs y handlers `IToolHandler` | Implementada como `src/tools/` con 8 handlers concretos y un `ToolRegistry` | [02](02-infraestructura-orquestacion.md#tool-handlers-del-agente-srctools) |
+| Adaptadores `IChatChannel` (`whatsapp.adapter.ts`, `telegram.adapter.ts`, `web-chat.adapter.ts`) | La interfaz `IChatChannel` existe pero no se implementa; el parseo de los tres canales vive directamente en `WebhookController`. Marcado como deuda técnica pendiente de refactor | [02](02-infraestructura-orquestacion.md#adaptadores-de-canal-srcchannels) |
+| `database-per-tenant` vía Prisma versionado por el sistema | Confirmado: `TenantConfigService` mantiene un pool de `PrismaClient` por tenant, sin eviction policy explícita | [02](02-infraestructura-orquestacion.md#pool-de-conexiones-prisma-por-tenant) |
+| Envelope tipado `ToolCallResult<T>` | Confirmado en los 8 tool handlers, con códigos de error estandarizados (`VALIDATION_ERROR`, `STAGE_PRECONDITION_FAILED`, etc.) | [02](02-infraestructura-orquestacion.md#tool-handlers-del-agente-srctools) |
+
+## Riesgos transversales
+
+Consolidando lo identificado en los tres documentos:
+
+- **Configuración de demo dispersa:** la GUI y el bridge de WhatsApp usan valores codificados que pueden desincronizarse del backend ([01](01-configuracion-prisma-demo.md#riesgos-y-cosas-a-tener-en-cuenta)).
+- **Adaptadores de canal no extraídos:** la lógica de `WhatsApp`/`Telegram`/`Web` vive en el controlador en lugar de en clases `IChatChannel` independientes, lo que dificulta agregar canales nuevos sin tocar el controlador ([02](02-infraestructura-orquestacion.md#adaptadores-de-canal-srcchannels)).
+- **Estado en memoria de un solo proceso:** el contador de `exploitReincidente` en `ScoringService` vive en memoria del proceso y no sobrevive reinicios ni escala horizontalmente ([03](03-servicios-dominio-notificaciones.md#riesgos-y-cosas-a-tener-en-cuenta)).
+- **Exportación de trazas síncrona:** `SimpleSpanProcessor` en `src/observability/tracing.ts` exporta cada span de forma síncrona, lo cual no escala a producción con volumen alto ([03](03-servicios-dominio-notificaciones.md#riesgos-y-cosas-a-tener-en-cuenta)).
+- **Auditoría silenciosa:** `AuditLogService.record` traga errores de escritura para no bloquear el flujo principal, pero eso puede dejar huecos no detectados en el registro append-only ([03](03-servicios-dominio-notificaciones.md#riesgos-y-cosas-a-tener-en-cuenta)).
+- **Desincronización Redis/DB en lista de espera:** no hay reconciliación automática entre el `Sorted Set` de Redis y la tabla `WaitingListEntry` ([03](03-servicios-dominio-notificaciones.md#riesgos-y-cosas-a-tener-en-cuenta)).
+
+## Estado de los sub-issues
+
+| Issue | Título | Estado | Entregable |
+| --- | --- | --- | --- |
+| #109 (PSD-42) | Análisis: Configuración base, Prisma y Demo | Cerrado | `docs/analisis-codigo/01-configuracion-prisma-demo.md` |
+| #110 (PSD-43) | Análisis: Infraestructura multi-tenant y orquestación del bot | Cerrado | `docs/analisis-codigo/02-infraestructura-orquestacion.md` |
+| #111 (PSD-44) | Análisis: Servicios de dominio, notificaciones y observabilidad | Cerrado | `docs/analisis-codigo/03-servicios-dominio-notificaciones.md` |
+
+Con los tres entregables cerrados y este resumen general publicado, se cumplen los criterios de aceptación del issue padre PSD-41 (#108).
+
+Fecha: 2026-06-25


### PR DESCRIPTION
## Resumen

Se agrega `docs/analisis-codigo/resumen-general.md`, el entregable del issue padre PSD-41 (#108): describe la arquitectura general del proyecto en tres capas (configuración base, infraestructura/orquestación, servicios de dominio) y referencia explícitamente los tres sub-documentos de análisis de código.

## Issues vinculados

- Closes #108
- Relates to #109
- Relates to #110
- Relates to #111
- [x] Verificar que todos los links apunten al issue correcto

## Impacto

- [x] Documentación
- [x] Trazabilidad
- [ ] Flujo operativo
- [ ] Entregable mensual o semanal

## Cambios principales

- [x] Se agrega `docs/analisis-codigo/resumen-general.md` con la arquitectura general en 3 capas y la tabla consolidada de módulos/CU
- [x] Se referencia explícitamente cada sub-documento (01, 02, 03) con rutas de archivo y enlaces a sus secciones
- [x] Se corrige formato Markdown en 02 y 03 (fence sin lenguaje, separador de tabla, salto de línea final) para pasar el lint de CI

## QA checklist

- [x] El diff corresponde al alcance declarado
- [x] No quedaron placeholders críticos
- [x] Los enlaces internos funcionan
- [x] La nomenclatura sigue el pipeline operativo
- [x] El impacto fue etiquetado correctamente
- [ ] La revisión fue validada por el responsable

## Riesgos y observaciones

- Observación: `docs/analisis-codigo/Max.md` y `Propuestas_Max.md` (notas internas de PSD-42) no son entregables formales del issue, pero aparecen en el diff porque ya estaban integrados en la rama base `108-psd-41-docs-analisis-codigo`.

## Evidencia

- [x] CI verde: `Update repository graph` + `Markdown lint`
- [x] Issues relacionados revisados (#109, #110, #111 cerrados)
- [x] Documentos afectados verificados
